### PR TITLE
Improve JSON output produced by `olly gc-stats`

### DIFF
--- a/bin/olly.ml
+++ b/bin/olly.ml
@@ -48,12 +48,16 @@ let print_percentiles json output hist =
   if json then
     let distribs =
       List.init (Array.length percentiles) (fun i ->
-          H.value_at_percentile hist percentiles.(i)
-          |> float_of_int |> ms |> string_of_float)
+          let percentile = percentiles.(i) in
+          let value =
+            H.value_at_percentile hist percentiles.(i)
+            |> float_of_int |> ms |> string_of_float
+          in
+          Printf.sprintf "\"%.4f\": %s" percentile value)
       |> String.concat ","
     in
     Printf.fprintf oc
-      {|{"mean_latency": %f, "max_latency": %f, "distr_latency": [%s]}|}
+      {|{"mean_latency": %f, "max_latency": %f, "distr_latency": {%s}}|}
       mean_latency max_latency distribs
   else (
     Printf.fprintf oc "\n";

--- a/bin/olly.ml
+++ b/bin/olly.ml
@@ -53,9 +53,8 @@ let print_percentiles json output hist =
       |> String.concat ","
     in
     Printf.fprintf oc
-      {|{"mean_latency": %d, "max_latency": %d, "distr_latency": [%s]}|}
-      (int_of_float mean_latency)
-      (int_of_float max_latency) distribs
+      {|{"mean_latency": %f, "max_latency": %f, "distr_latency": [%s]}|}
+      mean_latency max_latency distribs
   else (
     Printf.fprintf oc "\n";
     Printf.fprintf oc "Execution times:\n";


### PR DESCRIPTION
1. Fixes incorrect rounded off max_latency and mean_latency values.
2. Includes the percentile values in the latency distribution.