### PR TITLE
olly trace: ingest custom events

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### dev
+
+* olly trace: ingest custom events starting from OCaml 5.1
+
 ### 0.4.0
 
 * Fix dependencies (#14, @Sudha247)

--- a/bin/dune
+++ b/bin/dune
@@ -1,5 +1,17 @@
 (executable
  (public_name olly)
  (name olly)
- (modules olly)
+ (modules olly olly_custom_events)
  (libraries runtime_events unix hdr_histogram cmdliner tracing))
+
+(rule
+ (target olly_custom_events.ml)
+ (enabled_if (>= %{ocaml_version} 5.1.0))
+ (action
+  (copy olly_custom_events.yes.ml %{target})))
+
+(rule
+ (target olly_custom_events.ml)
+ (enabled_if (< %{ocaml_version} 5.1.0))
+ (action
+  (copy olly_custom_events.no.ml %{target})))

--- a/bin/dune
+++ b/bin/dune
@@ -6,12 +6,14 @@
 
 (rule
  (target olly_custom_events.ml)
- (enabled_if (>= %{ocaml_version} 5.1.0))
+ (enabled_if
+  (>= %{ocaml_version} 5.1.0))
  (action
   (copy olly_custom_events.yes.ml %{target})))
 
 (rule
  (target olly_custom_events.ml)
- (enabled_if (< %{ocaml_version} 5.1.0))
+ (enabled_if
+  (< %{ocaml_version} 5.1.0))
  (action
   (copy olly_custom_events.no.ml %{target})))

--- a/bin/olly.ml
+++ b/bin/olly.ml
@@ -82,8 +82,8 @@ let print_percentiles json output hist =
 let lost_events ring_id num =
   Printf.eprintf "[ring_id=%d] Lost %d events\n%!" ring_id num
 
-let olly ?extra ~runtime_begin ~runtime_end ~cleanup
-    ~lifecycle ~init exec_args =
+let olly ?extra ~runtime_begin ~runtime_end ~cleanup ~lifecycle ~init exec_args
+    =
   let argsl = String.split_on_char ' ' exec_args in
   let executable_filename = List.hd argsl in
 
@@ -196,8 +196,8 @@ let trace format trace_filename exec_args =
       let extra = Olly_custom_events.v trace_file doms in
       let init () = () in
       let cleanup () = Trace.close trace_file in
-      olly ~extra ~runtime_begin ~runtime_end ~init ~lifecycle
-        ~cleanup exec_args
+      olly ~extra ~runtime_begin ~runtime_end ~init ~lifecycle ~cleanup
+        exec_args
 
 let gc_stats json output exec_args =
   let current_event = Hashtbl.create 13 in

--- a/bin/olly_custom_events.no.ml
+++ b/bin/olly_custom_events.no.ml
@@ -1,0 +1,1 @@
+let v _trace_file _doms cb = cb

--- a/bin/olly_custom_events.yes.ml
+++ b/bin/olly_custom_events.yes.ml
@@ -1,4 +1,3 @@
-
 open Tracing
 module Ts = Runtime_events.Timestamp
 
@@ -9,30 +8,26 @@ let span trace_file doms ring_id ts ev value =
   let thread = doms.(ring_id) in
   let name = Runtime_events.User.name ev in
   let fn =
-    if value = Runtime_events.Type.Begin then
-      Trace.write_duration_begin
+    if value = Runtime_events.Type.Begin then Trace.write_duration_begin
     else Trace.write_duration_end
   in
-  fn trace_file ~args:[] ~thread ~category:"PERF"
-    ~name
+  fn trace_file ~args:[] ~thread ~category:"PERF" ~name
     ~time:(ts |> ts_to_int |> int_to_span)
 
 let int trace_file doms ring_id ts ev value =
   let thread = doms.(ring_id) in
   let name = Runtime_events.User.name ev in
-  Trace.write_counter trace_file ~args:[("v", Int value)] ~thread
-    ~category:"PERF"
-    ~name
+  Trace.write_counter trace_file
+    ~args:[ ("v", Int value) ]
+    ~thread ~category:"PERF" ~name
     ~time:(ts |> ts_to_int |> int_to_span)
 
 let unit trace_file doms ring_id ts ev () =
   let thread = doms.(ring_id) in
   let name = Runtime_events.User.name ev in
-  Trace.write_duration_instant trace_file ~args:[] ~thread
-    ~category:"PERF"
+  Trace.write_duration_instant trace_file ~args:[] ~thread ~category:"PERF"
     ~name
     ~time:(ts |> ts_to_int |> int_to_span)
-
 
 let v trace_file doms cb =
   let open Runtime_events in

--- a/bin/olly_custom_events.yes.ml
+++ b/bin/olly_custom_events.yes.ml
@@ -1,0 +1,42 @@
+
+open Tracing
+module Ts = Runtime_events.Timestamp
+
+let ts_to_int ts = ts |> Ts.to_int64 |> Int64.to_int
+let int_to_span i = Core.Time_ns.Span.of_int_ns i
+
+let span trace_file doms ring_id ts ev value =
+  let thread = doms.(ring_id) in
+  let name = Runtime_events.User.name ev in
+  let fn =
+    if value = Runtime_events.Type.Begin then
+      Trace.write_duration_begin
+    else Trace.write_duration_end
+  in
+  fn trace_file ~args:[] ~thread ~category:"PERF"
+    ~name
+    ~time:(ts |> ts_to_int |> int_to_span)
+
+let int trace_file doms ring_id ts ev value =
+  let thread = doms.(ring_id) in
+  let name = Runtime_events.User.name ev in
+  Trace.write_counter trace_file ~args:[("v", Int value)] ~thread
+    ~category:"PERF"
+    ~name
+    ~time:(ts |> ts_to_int |> int_to_span)
+
+let unit trace_file doms ring_id ts ev () =
+  let thread = doms.(ring_id) in
+  let name = Runtime_events.User.name ev in
+  Trace.write_duration_instant trace_file ~args:[] ~thread
+    ~category:"PERF"
+    ~name
+    ~time:(ts |> ts_to_int |> int_to_span)
+
+
+let v trace_file doms cb =
+  let open Runtime_events in
+  cb
+  |> Callbacks.add_user_event Type.span (span trace_file doms)
+  |> Callbacks.add_user_event Type.int (int trace_file doms)
+  |> Callbacks.add_user_event Type.unit (unit trace_file doms)

--- a/dune-project
+++ b/dune-project
@@ -13,6 +13,7 @@
 
 (package
  (name runtime_events_tools)
+ (sites (lib plugins))
  (synopsis "Tools for the runtime events tracing system in OCaml")
  (description "Various tools for the runtime events tracing system in OCaml")
  (depends

--- a/test/dune
+++ b/test/dune
@@ -14,7 +14,8 @@
 
 (rule
  (alias trace)
- (enabled_if (>= %{ocaml_version} 5.1.0))
+ (enabled_if
+  (>= %{ocaml_version} 5.1.0))
  (target test.trace)
  (deps
   (alias olly)
@@ -25,5 +26,6 @@
 
 (executable
  (name test)
- (enabled_if (>= %{ocaml_version} 5.1.0))
+ (enabled_if
+  (>= %{ocaml_version} 5.1.0))
  (libraries runtime_events unix))

--- a/test/dune
+++ b/test/dune
@@ -11,3 +11,19 @@
   ocaml.mly)
  (action
   (run olly gc-stats "menhir ocaml.mly")))
+
+(rule
+ (alias trace)
+ (enabled_if (>= %{ocaml_version} 5.1.0))
+ (target test.trace)
+ (deps
+  (alias olly)
+  test.exe)
+ (action
+  (progn
+   (run olly trace test.trace ./test.exe))))
+
+(executable
+ (name test)
+ (enabled_if (>= %{ocaml_version} 5.1.0))
+ (libraries runtime_events unix))

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,0 +1,20 @@
+open Runtime_events
+
+type User.tag += Custom
+
+let ev = User.register "fib" Custom Type.span
+
+let rec fib b =
+  match b with
+  | 0 -> 0
+  | 1 -> 1
+  | b ->
+    User.write ev Begin;
+    Unix.sleepf 0.0001;
+    let v1 = fib (b-1) in
+    Unix.sleepf 0.00005;
+    let v2 = fib (b-2) in
+    User.write ev End;
+    v1 + v2
+
+let _ = fib 5

--- a/test/test.ml
+++ b/test/test.ml
@@ -9,12 +9,12 @@ let rec fib b =
   | 0 -> 0
   | 1 -> 1
   | b ->
-    User.write ev Begin;
-    Unix.sleepf 0.0001;
-    let v1 = fib (b-1) in
-    Unix.sleepf 0.00005;
-    let v2 = fib (b-2) in
-    User.write ev End;
-    v1 + v2
+      User.write ev Begin;
+      Unix.sleepf 0.0001;
+      let v1 = fib (b - 1) in
+      Unix.sleepf 0.00005;
+      let v2 = fib (b - 2) in
+      User.write ev End;
+      v1 + v2
 
 let _ = fib 5


### PR DESCRIPTION
In 5.1 programmers will be able to add other runtime events. This PR modifies `olly trace` so that it includes custom events of common types (unit, int, span).

Conditional compilation was used to make it work on 5.0.
