### PR TITLE
Expand gc-stats help

### DIFF
--- a/bin/olly.ml
+++ b/bin/olly.ml
@@ -345,7 +345,7 @@ let () =
         `Blocks help_secs;
       ]
     in
-    let doc = "Report the GC latency profile and stats. Total time spent by the program performing garbage collection (major and minor)" in
+    let doc = "Report the GC latency profile and stats." in
     let info = Cmd.info "gc-stats" ~doc ~sdocs ~man in
     Cmd.v info Term.(const gc_stats $ json_option $ output_option $ exec_args 0)
   in

--- a/bin/olly.ml
+++ b/bin/olly.ml
@@ -342,6 +342,12 @@ let () =
       [
         `S Manpage.s_description;
         `P "Report the GC latency profile.";
+        `I ("Wall time", "Real execution time of the program");
+        `I ("CPU time", "Total CPU time across all domains");
+        `I ("GC time", "Total time spent by the program performing garbage collection (major and minor)");
+        `I ("GC overhead", "Percentage of time taken up by GC against the total execution time");
+        `I ("GC time per domain", "Time spent by every domain performing garbage collection (major and minor cycles). Domains are reported with their domain ID   (e.g. `Domain0`)");
+        `I ("GC latency profile", "Mean, standard deviation and percentile latency profile of GC events.");
         `Blocks help_secs;
       ]
     in

--- a/bin/olly.ml
+++ b/bin/olly.ml
@@ -345,7 +345,7 @@ let () =
         `Blocks help_secs;
       ]
     in
-    let doc = "Report the GC latency profile and stats." in
+    let doc = "Report the GC latency profile and stats. Total time spent by the program performing garbage collection (major and minor)" in
     let info = Cmd.info "gc-stats" ~doc ~sdocs ~man in
     Cmd.v info Term.(const gc_stats $ json_option $ output_option $ exec_args 0)
   in


### PR DESCRIPTION
Add information about gc-stats to --help command, using information already present in the README.

Made as part of OCaml hack event at Chennai on Oct 21st.

With help from Siva.