### PR TITLE
Remove irrelevant QCHECK_MSG_INTERVAL

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,6 @@ jobs:
   windows:
     runs-on: ubuntu-latest
 
-    env:
-      QCHECK_MSG_INTERVAL: '60'
-
     strategy:
       matrix:
         ocaml-compiler:


### PR DESCRIPTION
I spotted an irrelevant `QCHECK_MSG_INTERVAL` environment variable in the GitHub actions workflow.

That one is for reducing output from QCheck which isn't used here: https://github.com/c-cube/qcheck/pull/259