### PR TITLE
Remove ocamlfind dependency.

### DIFF
--- a/bin/olly.ml
+++ b/bin/olly.ml
@@ -344,10 +344,23 @@ let () =
         `P "Report the GC latency profile.";
         `I ("Wall time", "Real execution time of the program");
         `I ("CPU time", "Total CPU time across all domains");
-        `I ("GC time", "Total time spent by the program performing garbage collection (major and minor)");
-        `I ("GC overhead", "Percentage of time taken up by GC against the total execution time");
-        `I ("GC time per domain", "Time spent by every domain performing garbage collection (major and minor cycles). Domains are reported with their domain ID   (e.g. `Domain0`)");
-        `I ("GC latency profile", "Mean, standard deviation and percentile latency profile of GC events.");
+        `I
+          ( "GC time",
+            "Total time spent by the program performing garbage collection \
+             (major and minor)" );
+        `I
+          ( "GC overhead",
+            "Percentage of time taken up by GC against the total execution time"
+          );
+        `I
+          ( "GC time per domain",
+            "Time spent by every domain performing garbage collection (major \
+             and minor cycles). Domains are reported with their domain ID   \
+             (e.g. `Domain0`)" );
+        `I
+          ( "GC latency profile",
+            "Mean, standard deviation and percentile latency profile of GC \
+             events." );
         `Blocks help_secs;
       ]
     in

--- a/dune-project
+++ b/dune-project
@@ -18,7 +18,6 @@
  (description "Various tools for the runtime events tracing system in OCaml")
  (depends
   (ocaml (>= "5.0.0~"))
-  ocamlfind
   hdr_histogram
   cmdliner
   tracing

--- a/dune-project
+++ b/dune-project
@@ -19,6 +19,6 @@
  (depends
   (ocaml (>= "5.0.0~"))
   hdr_histogram
-  cmdliner
+  (cmdliner (>= 1.1.0))
   tracing
   (menhir :with-test)))

--- a/runtime_events_tools.opam
+++ b/runtime_events_tools.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "3.2"}
   "ocaml" {>= "5.0.0~"}
   "hdr_histogram"
-  "cmdliner"
+  "cmdliner" {>= "1.1.0"}
   "tracing"
   "menhir" {with-test}
   "odoc" {with-doc}

--- a/runtime_events_tools.opam
+++ b/runtime_events_tools.opam
@@ -11,7 +11,6 @@ bug-reports: "https://github.com/tarides/runtime_events_tools/issues"
 depends: [
   "dune" {>= "3.2"}
   "ocaml" {>= "5.0.0~"}
-  "ocamlfind"
   "hdr_histogram"
   "cmdliner"
   "tracing"


### PR DESCRIPTION
Fix for https://github.com/tarides/runtime_events_tools/issues/29