### PR TITLE
Prep release 0.5.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+
+### 0.5.1
+
+* Fix support on ARM64 platforms (Linux and MacOS) (#34, @tmcgilchrist)
+* Remove ocamlfind dependency. (#36, @tmcgilchrist)
+* Expand gc-stats help (#28, @ju-sh)
+
 ### 0.5.0
 
 * Custom events for json (#24, @Sudha247)

--- a/dune-project
+++ b/dune-project
@@ -21,4 +21,5 @@
   hdr_histogram
   (cmdliner (>= 1.1.0))
   tracing
+  (ocaml_intrinsics (>= v0.16.1))
   (menhir :with-test)))

--- a/runtime_events_tools.opam
+++ b/runtime_events_tools.opam
@@ -14,6 +14,7 @@ depends: [
   "hdr_histogram"
   "cmdliner" {>= "1.1.0"}
   "tracing"
+  "ocaml_intrinsics" {>= "v0.16.1"}
   "menhir" {with-test}
   "odoc" {with-doc}
 ]
@@ -32,9 +33,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/tarides/runtime_events_tools.git"
-pin-depends: [
-  # OCaml Intrinsics v0.16.0 plus ARM64 support see
-  # https://github.com/janestreet/ocaml_intrinsics/pull/6 and
-  # https://github.com/janestreet/ocaml_intrinsics/pull/7
-  "ocaml_intrinsics.v0.16.0" "git+https://github.com/tmcgilchrist/ocaml_intrinsics#fc6037516350f90e8d003c170263eaa734fc5e76"
-]
+available: (arch = "x86_64" | arch = "arm64") & os != "win32"

--- a/runtime_events_tools.opam.template
+++ b/runtime_events_tools.opam.template
@@ -1,6 +1,1 @@
-pin-depends: [
-  # OCaml Intrinsics v0.16.0 plus ARM64 support see
-  # https://github.com/janestreet/ocaml_intrinsics/pull/6 and
-  # https://github.com/janestreet/ocaml_intrinsics/pull/7
-  "ocaml_intrinsics.v0.16.0" "git+https://github.com/tmcgilchrist/ocaml_intrinsics#fc6037516350f90e8d003c170263eaa734fc5e76"
-]
+available: (arch = "x86_64" | arch = "arm64") & os != "win32"


### PR DESCRIPTION
Needs https://github.com/ocaml/opam-repository/pull/25300 to be merged first.

@Sudha247 I thought this should be a minor bug fix release. Only notable for restoring ARM64 support and fixes to cli help.