### PR TITLE
Allow olly to attach to an external process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,8 @@ jobs:
     strategy:
       matrix:
         ocaml-compiler:
-          - ocaml-base-compiler.5.1.1
+          - 5.1.1
+          - 5.2.0
         os:
           - ubuntu-latest
           - macos-14

--- a/lib/olly_common/cli.ml
+++ b/lib/olly_common/cli.ml
@@ -34,13 +34,63 @@ let help man_format cmds topic =
           `Ok (Manpage.print man_format Format.std_formatter page))
 
 let exec_args p =
-  let doc =
-    "Executable (and its arguments) to trace. If the executable takes\n\
-    \              arguments, wrap quotes around the executable and its \
-     arguments.\n\
-    \              For example, olly '<exec> <arg_1> <arg_2> ... <arg_n>'."
+  let exec_and_args, ea_docv =
+    let doc = "Executable and arguments to trace." in
+    let docv = "EXECUTABLE" in
+    (Arg.(value & pos_right (p - 1) string [] & info [] ~docv ~doc), docv)
   in
-  Arg.(required & pos p (some string) None & info [] ~docv:"EXECUTABLE" ~doc)
+  let attach_opt, ao_docv =
+    let doc =
+      "Attach to the process with the given PID. The directory containing the \
+       PID.events file may be specified. This option cannot be combined with \
+       EXECUTABLE."
+    in
+    let docv = "[directory:]pid" in
+    let parser str =
+      let exception Fail of string in
+      try
+        let dir, pid_str =
+          match String.rindex_opt str ':' with
+          | None -> (".", str)
+          | Some idx ->
+              ( String.sub str 0 idx,
+                String.sub str (idx + 1) (String.length str - idx - 1) )
+        in
+        let pid =
+          try int_of_string pid_str
+          with _ ->
+            raise (Fail (Printf.sprintf "expected integer pid, got %s" pid_str))
+        in
+        if not @@ Sys.file_exists dir then
+          raise (Fail (Printf.sprintf "directory %s does not exist" dir));
+        if not @@ Sys.is_directory dir then
+          raise (Fail (Printf.sprintf "file %s is not a directory" dir));
+        Ok (dir, pid)
+      with Fail msg -> Error msg
+    in
+    let printer fmt (dir, pid) =
+      match dir with
+      | "." -> Format.fprintf fmt "%d" pid
+      | _ -> Format.fprintf fmt "%s:%d" dir pid
+    in
+    let dir_and_pid_conv = Arg.conv' ~docv (parser, printer) in
+    ( Arg.(
+        value
+        & opt (some dir_and_pid_conv) None
+        & info [ "a"; "attach" ] ~docv ~doc),
+      docv )
+  in
+  let cat_docvs sep = Printf.sprintf "%s %s --attach=%s" ea_docv sep ao_docv in
+  let combine dir_and_pid args =
+    match (args, dir_and_pid) with
+    | [], Some (dir, pid) -> Ok (Launch.Attach (dir, pid))
+    | _ :: _, None -> Ok (Launch.Execute args)
+    | [], None ->
+        Error (Printf.sprintf "required %s is missing" (cat_docvs "or"))
+    | _ ->
+        Error (Printf.sprintf "more than one of %s specified" (cat_docvs "and"))
+  in
+  Term.(term_result' ~usage:true (const combine $ attach_opt $ exec_and_args))
 
 let main name commands =
   let help_cmd =

--- a/test/dune
+++ b/test/dune
@@ -23,7 +23,7 @@
  (package runtime_events_tools)
  (deps %{bin:olly} test_gc_stats.exe)
  (action
-  (run olly gc-stats "./test_gc_stats.exe 19")))
+  (run olly gc-stats ./test_gc_stats.exe 19)))
 
 (rule
  (alias runtest)


### PR DESCRIPTION
This PR allows olly to attach to an external process by directory and PID. That is, it implements #41.

I understand that @tmcgilchrist mentioned [here](https://github.com/tarides/runtime_events_tools/pull/43#issuecomment-2044129467) that he has already started working on an implementation, I hope I am not stepping on toes with this.

---

The primary non-obvious difference between this and the existing code in `launch.ml` is that `Unix.wait` cannot be used to determine if the process is still alive (you can only `wait` for children), and so `Unix.kill pid 0` is used instead. According to the [POSIX specification of `kill`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/kill.html):

> If sig is 0 (the null signal), error checking is performed but no signal is actually sent. The null signal can be used to check the validity of pid.

and

>  The kill() function shall fail if:
>    [EINVAL]
>        The value of the sig argument is an invalid or unsupported signal number.
>    [EPERM]
>        The process does not have permission to send the signal to any receiving process.
>    [ESRCH]
>        No process or process group can be found corresponding to that specified by pid.

So
```ocaml
let alive () =
  try Unix.kill pid 0; true
  with Unix.Unix_error (Unix.ESRCH, _, _) -> false
```
should work portably on Unix.

Olly currently already doesn't work on Windows due to how `Unix` handles PIDs ([badly](https://github.com/ocaml/ocaml/issues/11021)). I leave figuring out what to do with that for a later PR.

---

The second major change is how to actually handle this at the command line. Ideally, as mentioned [here](https://github.com/tarides/runtime_events_tools/issues/41#issuecomment-1969351582), we could do something like `olly gc-stats --attach pid`, while still allowing `olly gc-stats /path/to/program`.

`Cmdliner` has no clean way to express this, so I just specify `--attach` as a normal option and fail (still with a command line parsing error) if none/both are specified.

I also made `EXECUTABLE` be a sequence of arguments rather than just one space-split one, this makes expressing the above slightly easier. It is also in-line with existing tools like `perf record` or `gdb --args`, and allows olly to pass arguments (and execute programs) containing spaces. This part is technically backwards-incompatible, if that's a problem.