### PR TITLE
Fix executable arguments when launching a process. 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 ### Unreleased
 
 * Allow olly to attach to an external process (#45, @eutro)
+* Fix executable arguments when launching a process. (#55, @tmcgilchrist)
+* Emit runtime counter events for tracing (#46, @kayceesrk)
+* Make counters optional. (#49, @kayceesrk)
+* Fix GC stats to use timestamp from events (#48,  @kayceesrk)
 
 ### 0.5.1
 

--- a/dune-project
+++ b/dune-project
@@ -21,7 +21,8 @@
   (cmdliner (>= 1.1.0))
   tracing
   (ocaml_intrinsics (>= v0.16.1))
-  (menhir :with-test)))
+  (menhir :with-test)
+  (alcotest (and :with-test (>= 1.9.0)))))
 
 (package
  (name runtime_events_tools_bare)

--- a/lib/olly_common/cli.ml
+++ b/lib/olly_common/cli.ml
@@ -37,7 +37,9 @@ let exec_args p =
   let exec_and_args, ea_docv =
     let doc = "Executable and arguments to trace." in
     let docv = "EXECUTABLE" in
-    (Arg.(value & pos_right (p - 1) string [] & info [] ~docv ~doc), docv)
+    (* let str_list : string list Arg.conv = Arg.(list ~sep:' ' Arg.string) in *)
+    Term.(const List.concat $ Arg.(value & pos_right (p - 1) (list ~sep: ' ' string) [] & info [] ~docv ~doc), docv)
+
   in
   let attach_opt, ao_docv =
     let doc =
@@ -90,7 +92,8 @@ let exec_args p =
     | _ ->
         Error (Printf.sprintf "more than one of %s specified" (cat_docvs "and"))
   in
-  Term.(term_result' ~usage:true (const combine $ attach_opt $ exec_and_args))
+  Term.(term_result' ~usage:true (const combine $ attach_opt
+        $ exec_and_args))
 
 let main name commands =
   let help_cmd =

--- a/lib/olly_common/cli.ml
+++ b/lib/olly_common/cli.ml
@@ -37,9 +37,9 @@ let exec_args p =
   let exec_and_args, ea_docv =
     let doc = "Executable and arguments to trace." in
     let docv = "EXECUTABLE" in
-    (* let str_list : string list Arg.conv = Arg.(list ~sep:' ' Arg.string) in *)
-    Term.(const List.concat $ Arg.(value & pos_right (p - 1) (list ~sep: ' ' string) [] & info [] ~docv ~doc), docv)
-
+    Term.(const List.concat
+          $ Arg.(value & pos_right (p - 1) (list ~sep: ' ' string) []
+          & info [] ~docv ~doc), docv)
   in
   let attach_opt, ao_docv =
     let doc =
@@ -92,8 +92,7 @@ let exec_args p =
     | _ ->
         Error (Printf.sprintf "more than one of %s specified" (cat_docvs "and"))
   in
-  Term.(term_result' ~usage:true (const combine $ attach_opt
-        $ exec_and_args))
+  Term.(term_result' ~usage:true (const combine $ attach_opt $ exec_and_args))
 
 let main name commands =
   let help_cmd =

--- a/runtime_events_tools.opam
+++ b/runtime_events_tools.opam
@@ -16,6 +16,7 @@ depends: [
   "tracing"
   "ocaml_intrinsics" {>= "v0.16.1"}
   "menhir" {with-test}
+  "alcotest" {with-test & >= "1.9.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/test/dune
+++ b/test/dune
@@ -54,3 +54,17 @@
  (action
   (progn
    (run olly_bare trace --format=json test-bare-json.trace ./test_fib.exe))))
+
+; Dummy process for testing process launching.
+(executables
+ (names run_endlessly)
+ (libraries unix))
+
+(test
+ (name test_launch)
+ (package runtime_events_tools)
+ (enabled_if
+  (>= %{ocaml_version} 5.1.0))
+ (libraries olly_common alcotest)
+  (deps run_endlessly.exe)
+ (action (run %{test} --show-errors)))

--- a/test/run_endlessly.ml
+++ b/test/run_endlessly.ml
@@ -1,0 +1,5 @@
+let _ =
+  let i = ref 0 in
+  while true do
+    i := 42
+  done

--- a/test/test_launch.ml
+++ b/test/test_launch.ml
@@ -1,0 +1,49 @@
+let process_launch_failure () =
+  let open Olly_common in
+  let open Alcotest in
+  match_raises "executable not found on path should not launch"
+    (* Executable not found on path *)
+    (function
+     | Launch.Fail _ -> true
+     | _exn -> false)
+    (fun () -> ignore (Launch.exec_process ["missing.exe"]));
+
+  match_raises "non-executable should not launch"
+    (* File for exec_process is not an executable *)
+    (function
+     | Unix.Unix_error(Unix.EACCES, _, _) -> true
+     | _exn -> false)
+    (fun () -> ignore ( Launch.exec_process ["./run_endlessly.ml"]));
+
+  match_raises "empty executable string should not launch"
+    (* Empty executable string provided *)
+    (function
+     | Launch.Fail _ -> true
+     | _exn -> false)
+    (fun () -> ignore ( Launch.exec_process [""]))
+
+
+let process_launch () =
+  let open Olly_common in
+  Alcotest.(check bool) "process should launch" true
+    (try
+       let a = Launch.exec_process ["./run_endlessly.exe"] in
+       try
+         (* Sending signal Zero to kill checks the process exists for Unix. *)
+         Unix.kill a.pid 0;
+         true
+       with Unix.Unix_error (Unix.ESRCH, _, _) -> false
+
+     with
+     (* Any exceptions indicate a failure to launch *)
+     | Unix.Unix_error(Unix.ENOENT, _, _) -> false
+     | _exn -> Printf.printf "%s" (Printexc.to_string _exn); false)
+
+let () =
+  let open Alcotest in
+  run "Runtime Events Tools" [
+      "process",
+      [test_case "process::launch success" `Quick process_launch
+      ; test_case "process::launch failure" `Quick process_launch_failure
+      ]
+    ]


### PR DESCRIPTION
The Cmdliner argument parser was consuming the entire string without
splitting it into an executable followed by the arguments and passing
that as string list. This caused Unix.create_process_env to error out.