### PR TITLE
Test Windows CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,13 @@ jobs:
     strategy:
       matrix:
         ocaml-compiler:
-          - 5.1
-          - 5.2
+          # - 5.1
+          # - 5.2
           - 5.3
         os:
-          - ubuntu-latest
-          - macos-15
+          # - ubuntu-latest
+          # - macos-15
+          - windows-latest
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Draft PR to see what is broken with Windows support.

Requires a windows build setup for https://github.com/ocaml-multicore/hdr_histogram_ocaml 