### PR TITLE
Reinstate olly latency command.

### DIFF
--- a/bin/olly.ml
+++ b/bin/olly.ml
@@ -2,5 +2,6 @@ let () =
   let trace_cmd =
     Olly_trace.trace_cmd
       [ (module Olly_format_fuchsia); (module Olly_format_json) ]
-  and gc_stats_cmd = Olly_gc_stats.gc_stats_cmd in
-  Olly_common.Cli.main "olly" [ trace_cmd; gc_stats_cmd ]
+  and gc_stats_cmd = Olly_gc_stats.gc_stats_cmd
+  and latency_cmd = Olly_gc_stats.latency_cmd in
+  Olly_common.Cli.main "olly" [ trace_cmd; gc_stats_cmd; latency_cmd ]

--- a/dune-project
+++ b/dune-project
@@ -2,6 +2,7 @@
 
 (name runtime_events_tools)
 (generate_opam_files true)
+(cram enable)
 
 (source
  (github tarides/runtime_events_tools))

--- a/lib/olly_gc_stats/olly_gc_stats.ml
+++ b/lib/olly_gc_stats/olly_gc_stats.ml
@@ -107,6 +107,108 @@ let print_percentiles json output hist =
         Printf.fprintf oc "%.4f \t %.2f\n" p
           (float_of_int (H.value_at_percentile hist p) |> ms)))
 
+let print_latency_only json output hist =
+  let ms ns = ns /. 1_000_000. in
+
+  let mean_latency = H.mean hist |> ms
+  and max_latency = float_of_int (H.max hist) |> ms in
+  let percentiles =
+    [|
+      25.0;
+      50.0;
+      60.0;
+      70.0;
+      75.0;
+      80.0;
+      85.0;
+      90.0;
+      95.0;
+      96.0;
+      97.0;
+      98.0;
+      99.0;
+      99.9;
+      99.99;
+      99.999;
+      99.9999;
+      100.0;
+    |]
+  in
+  let oc = match output with Some s -> open_out s | None -> stderr in
+
+  if json then
+    let distribs =
+      List.init (Array.length percentiles) (fun i ->
+          let percentile = percentiles.(i) in
+          let value =
+            H.value_at_percentile hist percentiles.(i)
+            |> float_of_int |> ms |> string_of_float
+          in
+          Printf.sprintf "\"%.4f\": %s" percentile value)
+      |> String.concat ","
+    in
+    Printf.fprintf oc
+      {|{"mean_latency": %f, "max_latency": %f, "distr_latency": {%s}}|}
+      mean_latency max_latency distribs
+  else (
+    Printf.fprintf oc "\n";
+    Printf.fprintf oc "GC latency profile:\n";
+    Printf.fprintf oc "#[Mean (ms):\t%.2f,\t Stddev (ms):\t%.2f]\n" mean_latency
+      (H.stddev hist |> ms);
+    Printf.fprintf oc "#[Min (ms):\t%.2f,\t max (ms):\t%.2f]\n"
+      (float_of_int (H.min hist) |> ms)
+      max_latency;
+    Printf.fprintf oc "\n";
+    Printf.fprintf oc "Percentile \t Latency (ms)\n";
+    Fun.flip Array.iter percentiles (fun p ->
+        Printf.fprintf oc "%.4f \t %.2f\n" p
+          (float_of_int (H.value_at_percentile hist p) |> ms)))
+
+let latency poll_sleep json output runtime_events_dir exec_args =
+  let current_event = Hashtbl.create 13 in
+  let hist =
+    H.init ~lowest_discernible_value:10 ~highest_trackable_value:10_000_000_000
+      ~significant_figures:3
+  in
+  let is_gc_phase phase =
+    match phase with
+    | Runtime_events.EV_MAJOR | Runtime_events.EV_STW_LEADER
+    | Runtime_events.EV_INTERRUPT_REMOTE ->
+        true
+    | _ -> false
+  in
+  let runtime_begin ring_id ts phase =
+    if is_gc_phase phase then
+      match Hashtbl.find_opt current_event ring_id with
+      | None -> Hashtbl.add current_event ring_id (phase, Ts.to_int64 ts)
+      | _ -> ()
+  in
+  let runtime_end ring_id ts phase =
+    match Hashtbl.find_opt current_event ring_id with
+    | Some (saved_phase, saved_ts) when saved_phase = phase ->
+        Hashtbl.remove current_event ring_id;
+        let latency = Int64.to_int (Int64.sub (Ts.to_int64 ts) saved_ts) in
+        assert (H.record_value hist latency)
+    | _ -> ()
+  in
+  let init = Fun.id in
+  let cleanup () = print_latency_only json output hist in
+  let open Olly_common.Launch in
+  try
+    `Ok
+      (olly
+         {
+           empty_config with
+           runtime_begin;
+           runtime_end;
+           init;
+           cleanup;
+           poll_sleep;
+           runtime_events_dir;
+         }
+         exec_args)
+  with Fail msg -> `Error (false, msg)
+
 let gc_stats poll_sleep json output runtime_events_dir exec_args =
   let current_event = Hashtbl.create 13 in
   let hist =
@@ -206,4 +308,41 @@ let gc_stats_cmd =
     Term.(
       ret
         (const gc_stats $ freq_option $ json_option $ output_option
+       $ runtime_events_dir $ exec_args 0))
+
+let latency_cmd =
+  let open Cmdliner in
+  let open Olly_common.Cli in
+  let json_option =
+    let doc = "Print the output in json instead of human-readable format." in
+    Arg.(value & flag & info [ "json" ] ~docv:"json" ~doc)
+  in
+
+  let output_option =
+    let doc =
+      "Redirect the output of `olly` to specified file. The output of the \
+       command is not redirected."
+    in
+    Arg.(
+      value
+      & opt (some string) None
+      & info [ "o"; "output" ] ~docv:"output" ~doc)
+  in
+
+  let man =
+    [
+      `S Manpage.s_description;
+      `P
+        "Report the GC latency profile. This includes mean, standard deviation \
+         and percentile latency profile of GC events.";
+      `Blocks help_secs;
+    ]
+  in
+  let doc = "Report the GC latency profile." in
+  let info = Cmd.info "latency" ~doc ~sdocs ~man in
+
+  Cmd.v info
+    Term.(
+      ret
+        (const latency $ freq_option $ json_option $ output_option
        $ runtime_events_dir $ exec_args 0))

--- a/test/cram/dune
+++ b/test/cram/dune
@@ -1,0 +1,2 @@
+(cram
+ (deps %{bin:olly}))

--- a/test/cram/olly.t
+++ b/test/cram/olly.t
@@ -1,0 +1,266 @@
+Top-level help shows all subcommands including latency:
+  $ olly --help=plain
+  NAME
+         olly - An observability tool for OCaml programs
+  
+  SYNOPSIS
+         olly COMMAND …
+  
+  COMMANDS
+         gc-stats [OPTION]… [EXECUTABLE]…
+             Report the GC latency profile and stats.
+  
+         latency [OPTION]… [EXECUTABLE]…
+             Report the GC latency profile.
+  
+         trace [OPTION]… TRACEFILE [EXECUTABLE]…
+             Save the runtime trace to file.
+  
+  COMMON OPTIONS
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
+  
+  EXIT STATUS
+         olly exits with:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+
+Trace subcommand help:
+  $ olly trace --help=plain
+  NAME
+         olly-trace - Save the runtime trace to file.
+  
+  SYNOPSIS
+         olly trace [OPTION]… TRACEFILE [EXECUTABLE]…
+  
+  DESCRIPTION
+         Save the runtime trace to file.
+  
+  ARGUMENTS
+         EXECUTABLE
+             Executable and arguments to trace.
+  
+         TRACEFILE (required)
+             Target trace file name.
+  
+  OPTIONS
+         -a [directory:]pid, --attach=[directory:]pid
+             Attach to the process with the given PID. The directory containing
+             the PID.events file may be specified. This option cannot be
+             combined with EXECUTABLE.
+  
+         -c, --emit-counters
+             Emit runtime counter events.
+  
+         -d dir, --dir=dir
+             Sets the directory where the .events files containing the runtime
+             event tracing system’s ring buffers will be located. If not
+             specified a temporary directory will be used.
+  
+         -f format, --format=format (absent=fuchsia)
+             Format of the target trace, options are: "fuchsia" (Perfetto),
+             "json" (Chrome Trace Format).
+  
+         --freq=freq (absent=0.1)
+             Set the interval that olly sleeps in seconds, after performing a
+             [Runtime_events.read_poll]. Fractions of seconds are supported. A
+             value of 0.0 will skip sleeping altogether.
+  
+         --log-wsize=log-wsize
+             Size of the per-domain runtime events ring buffers in log powers
+             of two words. Defaults to 16.
+  
+  COMMON OPTIONS
+         These options are common to all commands.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
+  
+  MORE HELP
+         Use olly COMMAND --help for help on a single command.
+  EXIT STATUS
+         olly trace exits with:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  BUGS
+         Check bug reports at
+         http://github.com/tarides/runtime_events_tools/issues.
+  
+  SEE ALSO
+         olly(1)
+  
+
+GC stats subcommand help:
+  $ olly gc-stats --help=plain
+  NAME
+         olly-gc-stats - Report the GC latency profile and stats.
+  
+  SYNOPSIS
+         olly gc-stats [OPTION]… [EXECUTABLE]…
+  
+  DESCRIPTION
+         Report the GC latency profile.
+  
+         Wall time
+             Real execution time of the program
+  
+         CPU time
+             Total CPU time across all domains
+  
+         GC time
+             Total time spent by the program performing garbage collection
+             (major and minor)
+  
+         GC overhead
+             Percentage of time taken up by GC against the total execution time
+  
+         GC time per domain
+             Time spent by every domain performing garbage collection (major
+             and minor cycles). Domains are reported with their domain ID (e.g.
+             `Domain0`)
+  
+         GC latency profile
+             Mean, standard deviation and percentile latency profile of GC
+             events.
+  
+  ARGUMENTS
+         EXECUTABLE
+             Executable and arguments to trace.
+  
+  OPTIONS
+         -a [directory:]pid, --attach=[directory:]pid
+             Attach to the process with the given PID. The directory containing
+             the PID.events file may be specified. This option cannot be
+             combined with EXECUTABLE.
+  
+         -d dir, --dir=dir
+             Sets the directory where the .events files containing the runtime
+             event tracing system’s ring buffers will be located. If not
+             specified a temporary directory will be used.
+  
+         --freq=freq (absent=0.1)
+             Set the interval that olly sleeps in seconds, after performing a
+             [Runtime_events.read_poll]. Fractions of seconds are supported. A
+             value of 0.0 will skip sleeping altogether.
+  
+         --json
+             Print the output in json instead of human-readable format.
+  
+         -o output, --output=output
+             Redirect the output of `olly` to specified file. The output of the
+             command is not redirected.
+  
+  COMMON OPTIONS
+         These options are common to all commands.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
+  
+  MORE HELP
+         Use olly COMMAND --help for help on a single command.
+  EXIT STATUS
+         olly gc-stats exits with:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  BUGS
+         Check bug reports at
+         http://github.com/tarides/runtime_events_tools/issues.
+  
+  SEE ALSO
+         olly(1)
+  
+
+Latency subcommand help:
+  $ olly latency --help=plain
+  NAME
+         olly-latency - Report the GC latency profile.
+  
+  SYNOPSIS
+         olly latency [OPTION]… [EXECUTABLE]…
+  
+  DESCRIPTION
+         Report the GC latency profile. This includes mean, standard deviation
+         and percentile latency profile of GC events.
+  
+  ARGUMENTS
+         EXECUTABLE
+             Executable and arguments to trace.
+  
+  OPTIONS
+         -a [directory:]pid, --attach=[directory:]pid
+             Attach to the process with the given PID. The directory containing
+             the PID.events file may be specified. This option cannot be
+             combined with EXECUTABLE.
+  
+         -d dir, --dir=dir
+             Sets the directory where the .events files containing the runtime
+             event tracing system’s ring buffers will be located. If not
+             specified a temporary directory will be used.
+  
+         --freq=freq (absent=0.1)
+             Set the interval that olly sleeps in seconds, after performing a
+             [Runtime_events.read_poll]. Fractions of seconds are supported. A
+             value of 0.0 will skip sleeping altogether.
+  
+         --json
+             Print the output in json instead of human-readable format.
+  
+         -o output, --output=output
+             Redirect the output of `olly` to specified file. The output of the
+             command is not redirected.
+  
+  COMMON OPTIONS
+         These options are common to all commands.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
+  
+  MORE HELP
+         Use olly COMMAND --help for help on a single command.
+  EXIT STATUS
+         olly latency exits with:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  BUGS
+         Check bug reports at
+         http://github.com/tarides/runtime_events_tools/issues.
+  
+  SEE ALSO
+         olly(1)
+  

--- a/test/dune
+++ b/test/dune
@@ -28,6 +28,13 @@
 (rule
  (alias runtest)
  (package runtime_events_tools)
+ (deps %{bin:olly} test_gc_stats.exe)
+ (action
+  (run olly latency "./test_gc_stats.exe")))
+
+(rule
+ (alias runtest)
+ (package runtime_events_tools)
  (enabled_if
   (>= %{ocaml_version} 5.1.0))
  (deps %{bin:olly} test_fib.exe)


### PR DESCRIPTION
This is referenced from the OCaml manual versions 5.0 to 5.4

Fixes https://github.com/tarides/runtime_events_tools/issues/82