### PR TITLE
Report lost events at end of run

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 ### 0.5.3
+* Sample max RSS usage from a dedicated domain (#95, @ngorogiannis)
 * Record and don't crash on latencies above histogram threshold (#93, @ngorogiannis)
 * Extract common code between gc stats implementations for OCaml 5.0 and 5.3 (#93, @ngorogiannis)
 * Reinstate olly latency command. (#86, @tmcgilchrist)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 ### 0.5.3
+* Report lost events count only at end of run (#96, @ngorogiannis)
 * Sample max RSS usage from a dedicated domain (#95, @ngorogiannis)
 * Record and don't crash on latencies above histogram threshold (#93, @ngorogiannis)
 * Extract common code between gc stats implementations for OCaml 5.0 and 5.3 (#93, @ngorogiannis)

--- a/lib/olly_common/cli.ml
+++ b/lib/olly_common/cli.ml
@@ -1,5 +1,14 @@
 open Cmdliner
 
+let positive_float =
+  let parse s =
+    let f = Arg.Conv.parser Arg.float s in
+    Result.bind f (fun f ->
+        if f > 0.0 then Ok f
+        else Error (Printf.sprintf "%g is not a positive value" f))
+  in
+  Arg.Conv.of_conv ~parser:parse Arg.float
+
 let help_secs =
   [
     `S Manpage.s_common_options;
@@ -25,6 +34,20 @@ let freq_option =
     value
     & opt float 0.1 (* Poll at 10Hz by default. *)
     & info [ "freq" ] ~docv:"freq" ~doc)
+
+let rss_freq_option =
+  let doc =
+    "Set the interval, in seconds, at which the peak RSS of the monitored \
+     process is sampled. Sampling runs on a dedicated domain, independently of \
+     $(b,--freq). The value must be positive. On Linux, the tracked value is \
+     monotonic so reducing the interval improves accuracy only within the last \
+     iteration. On OSX and FreeBSD, there is a genuine accuracy/overhead \
+     tradeoff."
+  in
+  Arg.(
+    value
+    & opt positive_float 0.1 (* Sample at 10Hz by default. *)
+    & info [ "rss-freq" ] ~docv:"rss-freq" ~doc)
 
 let runtime_events_dir =
   let doc =

--- a/lib/olly_common/launch.ml
+++ b/lib/olly_common/launch.ml
@@ -140,7 +140,7 @@ let launch_process config (exec_args : exec_config) : subprocess =
 
 let interrupted = Atomic.make false
 
-let collect_events poll_sleep ~on_poll child callbacks =
+let collect_events poll_sleep child callbacks =
   let old_handler =
     Sys.signal Sys.sigint
       (Sys.Signal_handle (fun _ -> Atomic.set interrupted true))
@@ -150,7 +150,6 @@ let collect_events poll_sleep ~on_poll child callbacks =
     (fun () ->
       (* Read from the child process *)
       while child.alive () && not (Atomic.get interrupted) do
-        on_poll child.pid;
         Runtime_events.read_poll child.cursor callbacks None |> ignore;
         if poll_sleep > 0.0 then
           try Unix.sleepf poll_sleep
@@ -169,7 +168,7 @@ type consumer_config = {
   extra : Runtime_events.Callbacks.t -> Runtime_events.Callbacks.t;
   init : unit -> unit;
   cleanup : unit -> unit;
-  on_poll : int -> unit;
+  on_launch : subprocess -> unit;
   poll_sleep : float;
   runtime_events_dir : string option;
   runtime_events_log_wsize : int option;
@@ -184,7 +183,7 @@ let empty_config =
     extra = Fun.id;
     init = (fun () -> ());
     cleanup = (fun () -> ());
-    on_poll = (fun _ -> ());
+    on_launch = (fun _ -> ());
     poll_sleep = 0.1 (* Poll at 10Hz *);
     runtime_events_dir = None;
     (* Use default tmp directory *)
@@ -203,6 +202,7 @@ let olly config exec_args =
       in
       let child = launch_process runtime_config exec_args in
       Fun.protect ~finally:child.close (fun () ->
+          config.on_launch child;
           let callbacks =
             let {
               runtime_begin;
@@ -218,5 +218,4 @@ let olly config exec_args =
               ~runtime_counter ~lifecycle ~lost_events ()
             |> extra
           in
-          collect_events config.poll_sleep ~on_poll:config.on_poll child
-            callbacks))
+          collect_events config.poll_sleep child callbacks))

--- a/lib/olly_common/launch.ml
+++ b/lib/olly_common/launch.ml
@@ -1,7 +1,11 @@
 external is_process_alive : int -> bool = "olly_is_process_alive"
 
-let lost_events ring_id num =
-  Printf.eprintf "[ring_id=%d] Lost %d events\n%!" ring_id num
+let lost_events_count = ref 0
+
+let lost_events _ring_id num =
+  let sum = !lost_events_count + num in
+  (* detect overflow and stay at [max_int] *)
+  lost_events_count := if sum < 0 then max_int else sum
 
 type subprocess = {
   alive : unit -> bool;
@@ -193,7 +197,17 @@ let empty_config =
 
 let olly config exec_args =
   config.init ();
-  Fun.protect ~finally:config.cleanup (fun () ->
+  let finally () =
+    config.cleanup ();
+    if !lost_events_count > 0 then begin
+      Printf.eprintf "Lost %d events, stats not reliable%s\n%!"
+        !lost_events_count
+        (if !lost_events_count = max_int then
+           " (possible counter overflow detected)\n%!"
+         else "")
+    end
+  in
+  Fun.protect ~finally (fun () ->
       let runtime_config =
         {
           dir = config.runtime_events_dir;

--- a/lib/olly_common/max_rss.ml
+++ b/lib/olly_common/max_rss.ml
@@ -1,11 +1,5 @@
-external get_rss_kb : int -> int = "olly_get_rss_kb"
-
 type t = { mutable max_rss_kb : int }
 
 let create () = { max_rss_kb = 0 }
-
-let sample t pid =
-  let rss = get_rss_kb pid in
-  if rss > t.max_rss_kb then t.max_rss_kb <- rss
-
+let set t kb = if kb > t.max_rss_kb then t.max_rss_kb <- kb
 let max_rss_kb t = t.max_rss_kb

--- a/lib/olly_common/rss_poller.ml
+++ b/lib/olly_common/rss_poller.ml
@@ -1,0 +1,32 @@
+external get_rss_kb : int -> int = "olly_get_rss_kb"
+
+type t = { stop_flag : bool Atomic.t; domain : int Domain.t }
+
+let rss_poller : t option ref = ref None
+
+let start ~pid ~interval =
+  if Option.is_some !rss_poller then failwith "RSS Poller already started";
+  if interval <= 0.0 then invalid_arg "interval must be positive";
+  let stop_flag = Atomic.make false in
+  let domain =
+    Domain.spawn (fun () ->
+        let rec loop peak =
+          if Atomic.get stop_flag then peak
+          else begin
+            (* sample before waiting so that we get a reading at launch *)
+            let rss = get_rss_kb pid in
+            (try Unix.sleepf interval
+             with Unix.Unix_error (Unix.EINTR, _, _) -> ());
+            loop (max rss peak)
+          end
+        in
+        loop 0)
+  in
+  rss_poller := Some { stop_flag; domain }
+
+let stop () =
+  match !rss_poller with
+  | None -> failwith "RSS Poller not running"
+  | Some t ->
+      Atomic.set t.stop_flag true;
+      Domain.join t.domain

--- a/lib/olly_common/rss_poller.mli
+++ b/lib/olly_common/rss_poller.mli
@@ -1,0 +1,9 @@
+(** Sample a process's peak resident set size from a dedicated domain. *)
+
+val start : pid:int -> interval:float -> unit
+(** [start ~pid ~interval] spawns a domain that samples the RSS of [pid] every
+    [interval] seconds, tracking the peak. [interval] must be positive. *)
+
+val stop : unit -> int
+(** [stop t] signals the poller to stop, waits for it to finish, and returns the
+    peak RSS observed, in kB. *)

--- a/lib/olly_gc_stats/olly_gc_stats.5.0.ml
+++ b/lib/olly_gc_stats/olly_gc_stats.5.0.ml
@@ -146,8 +146,8 @@ let print_percentiles json output hist outliers =
       !major_collections !forced_major_collections;
     Printf.fprintf oc "Compactions: %i\n" !compactions)
 
-let gc_stats poll_sleep json output runtime_events_dir runtime_events_log_wsize
-    exec_args =
+let gc_stats poll_sleep rss_freq json output runtime_events_dir
+    runtime_events_log_wsize exec_args =
   let current_event = Hashtbl.create 13 in
   let hist = make_hist () in
   let outliers = make_outliers () in
@@ -209,9 +209,14 @@ let gc_stats poll_sleep json output runtime_events_dir runtime_events_log_wsize
   in
 
   let init = Fun.id in
-  let cleanup () = print_percentiles json output hist outliers in
-  let on_poll = Olly_common.Max_rss.sample rss_collector in
   let open Olly_common.Launch in
+  let on_launch (child : subprocess) =
+    Olly_common.Rss_poller.start ~pid:child.pid ~interval:rss_freq
+  in
+  let cleanup () =
+    Olly_common.Max_rss.set rss_collector (Olly_common.Rss_poller.stop ());
+    print_percentiles json output hist outliers
+  in
   try
     `Ok
       (olly
@@ -223,7 +228,7 @@ let gc_stats poll_sleep json output runtime_events_dir runtime_events_log_wsize
            lifecycle;
            init;
            cleanup;
-           on_poll;
+           on_launch;
            poll_sleep;
            runtime_events_dir;
            runtime_events_log_wsize;

--- a/lib/olly_gc_stats/olly_gc_stats.5.3.ml
+++ b/lib/olly_gc_stats/olly_gc_stats.5.3.ml
@@ -216,8 +216,8 @@ let print_percentiles json output hist outliers =
       !major_collections !forced_major_collections;
     Printf.fprintf oc "Compactions: %i\n" !compactions)
 
-let gc_stats poll_sleep json output runtime_events_dir runtime_events_log_wsize
-    exec_args =
+let gc_stats poll_sleep rss_freq json output runtime_events_dir
+    runtime_events_log_wsize exec_args =
   let current_event = Hashtbl.create 13 in
   let hist = make_hist () in
   let outliers = make_outliers () in
@@ -283,9 +283,14 @@ let gc_stats poll_sleep json output runtime_events_dir runtime_events_log_wsize
   in
 
   let init = Fun.id in
-  let cleanup () = print_percentiles json output hist outliers in
-  let on_poll = Olly_common.Max_rss.sample rss_collector in
   let open Olly_common.Launch in
+  let on_launch (child : subprocess) =
+    Olly_common.Rss_poller.start ~pid:child.pid ~interval:rss_freq
+  in
+  let cleanup () =
+    Olly_common.Max_rss.set rss_collector (Olly_common.Rss_poller.stop ());
+    print_percentiles json output hist outliers
+  in
   try
     `Ok
       (olly
@@ -297,7 +302,7 @@ let gc_stats poll_sleep json output runtime_events_dir runtime_events_log_wsize
            lifecycle;
            init;
            cleanup;
-           on_poll;
+           on_launch;
            poll_sleep;
            runtime_events_dir;
            runtime_events_log_wsize;

--- a/lib/olly_gc_stats/olly_gc_stats.ml
+++ b/lib/olly_gc_stats/olly_gc_stats.ml
@@ -48,7 +48,8 @@ let gc_stats_cmd =
       `I
         ( "Max RSS",
           "Peak resident set size (in kB) of the child process, sampled during \
-           execution." );
+           execution. The sampling interval is controlled by $(b,--rss-freq) \
+           and is independent of $(b,--freq)." );
       `Blocks help_secs;
     ]
   in
@@ -59,8 +60,8 @@ let gc_stats_cmd =
     Term.(
       ret
         (const Olly_gc_impl.gc_stats
-        $ freq_option $ json_option $ output_option $ runtime_events_dir
-        $ runtime_events_log_wsize $ exec_args 0))
+        $ freq_option $ rss_freq_option $ json_option $ output_option
+        $ runtime_events_dir $ runtime_events_log_wsize $ exec_args 0))
 
 let latency_cmd =
   let open Cmdliner in

--- a/lib/olly_gc_stats/olly_gc_stats_common.ml
+++ b/lib/olly_gc_stats/olly_gc_stats_common.ml
@@ -22,7 +22,9 @@ let make_hist () =
 (* Largest GC pause (in nanoseconds) the latency histogram can track. Pauses
    beyond this are summarised separately. This should be calculated through the hist implementation 
    and the concrete arguments in [make_hist] *)
-let highest_trackable_value = 2 lsl 34
+let highest_trackable_value = 1 lsl 34
+
+(* Mutable stats *)
 let wall_time = { start_time = 0.; end_time = 0. }
 let rss_collector = Olly_common.Max_rss.create ()
 let domain_elapsed_times = Array.make number_domains 0.
@@ -33,6 +35,8 @@ let minor_collections = ref 0
 let major_collections = ref 0
 let forced_major_collections = ref 0
 let compactions = ref 0
+
+(* conversions *)
 let to_sec x = float_of_int x /. 1_000_000_000.
 let ms ns = ns /. 1_000_000.
 let mean_latency hist = H.mean hist |> ms

--- a/lib/olly_trace/olly_trace.ml
+++ b/lib/olly_trace/olly_trace.ml
@@ -28,7 +28,7 @@ let trace poll_sleep fmt trace_filename emit_counter runtime_events_dir
   and runtime_end = runtime_phase SpanEnd
   and init () = ()
   and cleanup () = Format.close tracer
-  and on_poll = fun _ -> ()
+  and on_launch = fun _ -> ()
   and extra = Olly_custom_events.v tracer
   and lifecycle _ _ _ _ = () in
   let open Olly_common.Launch in
@@ -41,7 +41,7 @@ let trace poll_sleep fmt trace_filename emit_counter runtime_events_dir
       lifecycle;
       init;
       cleanup;
-      on_poll;
+      on_launch;
       poll_sleep;
       runtime_events_dir;
       runtime_events_log_wsize;

--- a/test/cram/olly.t
+++ b/test/cram/olly.t
@@ -147,7 +147,8 @@ GC stats subcommand help:
   
          Max RSS
              Peak resident set size (in kB) of the child process, sampled
-             during execution.
+             during execution. The sampling interval is controlled by
+             --rss-freq and is independent of --freq.
   
   ARGUMENTS
          EXECUTABLE
@@ -179,6 +180,14 @@ GC stats subcommand help:
          -o output, --output=output
              Redirect the output of `olly` to specified file. The output of the
              command is not redirected.
+  
+         --rss-freq=rss-freq (absent=0.1)
+             Set the interval, in seconds, at which the peak RSS of the
+             monitored process is sampled. Sampling runs on a dedicated domain,
+             independently of --freq. The value must be positive. On Linux, the
+             tracked value is monotonic so reducing the interval improves
+             accuracy only within the last iteration. On OSX and FreeBSD, there
+             is a genuine accuracy/overhead tradeoff.
   
   COMMON OPTIONS
          These options are common to all commands.


### PR DESCRIPTION
Currently, when events are lost a message is printed to stderr, which is flushed.
This can lead to more event loss, as it blocks the event loop. 
We change to a simple counter that is printed at the end of the run if positive.

NB stacked on top of https://github.com/tarides/runtime_events_tools/pull/95