### PR TITLE
Output whether events were lost in json

### DIFF
--- a/lib/olly_common/launch.ml
+++ b/lib/olly_common/launch.ml
@@ -1,11 +1,24 @@
 external is_process_alive : int -> bool = "olly_is_process_alive"
 
-let lost_events_count = ref 0
+module Lost_events = struct
+  let lost_events_count = ref 0
 
-let lost_events _ring_id num =
-  let sum = !lost_events_count + num in
-  (* detect overflow and stay at [max_int] *)
-  lost_events_count := if sum < 0 then max_int else sum
+  let callback _ring_id num =
+    let sum = !lost_events_count + num in
+    (* detect overflow and stay at [max_int] *)
+    lost_events_count := if sum < 0 then max_int else sum
+
+  let were_events_lost () = !lost_events_count > 0
+
+  let display () =
+    if were_events_lost () then begin
+      Printf.eprintf "Lost %d events, stats not reliable%s\n%!"
+        !lost_events_count
+        (if !lost_events_count = max_int then
+           " (possible counter overflow detected)\n%!"
+         else "")
+    end
+end
 
 type subprocess = {
   alive : unit -> bool;
@@ -199,13 +212,7 @@ let olly config exec_args =
   config.init ();
   let finally () =
     config.cleanup ();
-    if !lost_events_count > 0 then begin
-      Printf.eprintf "Lost %d events, stats not reliable%s\n%!"
-        !lost_events_count
-        (if !lost_events_count = max_int then
-           " (possible counter overflow detected)\n%!"
-         else "")
-    end
+    Lost_events.display ()
   in
   Fun.protect ~finally (fun () ->
       let runtime_config =
@@ -228,6 +235,7 @@ let olly config exec_args =
             } =
               config
             in
+            let lost_events = Lost_events.callback in
             Runtime_events.Callbacks.create ~runtime_begin ~runtime_end
               ~runtime_counter ~lifecycle ~lost_events ()
             |> extra

--- a/lib/olly_gc_stats/olly_gc_stats.5.0.ml
+++ b/lib/olly_gc_stats/olly_gc_stats.5.0.ml
@@ -80,7 +80,38 @@ let print_percentiles json output hist outliers =
       Buffer.contents buf
     in
     Printf.fprintf oc
-      {|{"version": 2, "wall_time": %.2f, "cpu_time": %.2f, "gc_time": %.2f, "gc_overhead": %.2f, "max_rss_kb": %d, "domain_stats": {%s}, "mean_latency": %f, "stddev_latency": %f, "min_latency": %.2f, "max_latency": %f, "distr_latency": {%s}, "outliers": {"count": %d, "mean_latency": %f, "max_latency": %f}, "allocations": {"total_heap": %.0f, "minor_heap": %.0f, "promoted_words": %.0f, "promoted_pct": %.2f}, "collections": {"minor": %i, "major": %i, "forced_major": %i, "compactions": %i}}|}
+      {|{       
+  "version": 2,       
+  "wall_time": %.2f,       
+  "cpu_time": %.2f,       
+  "gc_time": %.2f,       
+  "gc_overhead": %.2f,       
+  "max_rss_kb": %d,       
+  "domain_stats": {%s},       
+  "mean_latency": %f,       
+  "stddev_latency": %f,       
+  "min_latency": %.2f,       
+  "max_latency": %f,       
+  "distr_latency": {%s},       
+  "outliers": {       
+    "count": %d,       
+    "mean_latency": %f,       
+    "max_latency": %f
+  },       
+  "allocations": {       
+    "total_heap": %.0f,       
+    "minor_heap": %.0f,       
+    "promoted_words": %.0f,       
+    "promoted_pct": %.2f
+  },       
+  "collections": {       
+    "minor": %i,       
+    "major": %i,       
+    "forced_major": %i,       
+    "compactions": %i
+  },       
+  "stats-reliable": %b
+}|}
       real_time !total_cpu_time total_gc_time gc_overhead
       (Olly_common.Max_rss.max_rss_kb rss_collector)
       domain_stats mean_latency stddev_latency min_latency max_latency distribs
@@ -88,6 +119,7 @@ let print_percentiles json output hist outliers =
       (float_of_int outliers.max |> ms)
       total_heap !minor_words !promoted_words promoted_pct !minor_collections
       !major_collections !forced_major_collections !compactions
+      (not @@ Olly_common.Launch.Lost_events.were_events_lost ())
   else (
     Printf.fprintf oc "\n";
     Printf.fprintf oc "Execution times:\n";

--- a/lib/olly_gc_stats/olly_gc_stats.5.3.ml
+++ b/lib/olly_gc_stats/olly_gc_stats.5.3.ml
@@ -153,7 +153,40 @@ let print_percentiles json output hist outliers =
       Buffer.contents buf
     in
     Printf.fprintf oc
-      {|{"version": 2, "wall_time": %.2f, "cpu_time": %.2f, "gc_time": %.2f, "gc_overhead": %.2f, "max_rss_kb": %d, "domain_stats": {%s}, "mean_latency": %f, "stddev_latency": %f, "min_latency": %.2f, "max_latency": %f, "distr_latency": {%s}, "outliers": {"count": %d, "mean_latency": %f, "max_latency": %f}, "allocations": {"total_heap": %.0f, "minor_heap": %.0f, "major_heap": %.0f, "promoted_words": %.0f, "promoted_pct": %.2f}, "domain_alloc_stats": {%s}, "collections": {"minor": %i, "major": %i, "forced_major": %i, "compactions": %i}}|}
+      {|{       
+  "version": 2,       
+  "wall_time": %.2f,       
+  "cpu_time": %.2f,       
+  "gc_time": %.2f,       
+  "gc_overhead": %.2f,       
+  "max_rss_kb": %d,       
+  "domain_stats": {%s},       
+  "mean_latency": %f,       
+  "stddev_latency": %f,       
+  "min_latency": %.2f,       
+  "max_latency": %f,       
+  "distr_latency": {%s},       
+  "outliers": {       
+    "count": %d,       
+    "mean_latency": %f,       
+    "max_latency": %f
+  },       
+  "allocations": {       
+    "total_heap": %.0f,       
+    "minor_heap": %.0f,       
+    "major_heap": %.0f,       
+    "promoted_words": %.0f,       
+    "promoted_pct": %.2f
+  },       
+  "domain_alloc_stats": {%s},       
+  "collections": {       
+    "minor": %i,       
+    "major": %i,       
+    "forced_major": %i,       
+    "compactions": %i
+  },       
+  "stats_reliable": %b
+}|}
       real_time !total_cpu_time total_gc_time gc_overhead
       (Olly_common.Max_rss.max_rss_kb rss_collector)
       domain_stats mean_latency stddev_latency min_latency max_latency distribs
@@ -162,6 +195,7 @@ let print_percentiles json output hist outliers =
       total_heap !minor_words !major_words !promoted_words promoted_pct
       domain_alloc_stats !minor_collections !major_collections
       !forced_major_collections !compactions
+      (not @@ Olly_common.Launch.Lost_events.were_events_lost ())
   else (
     Printf.fprintf oc "\n";
     Printf.fprintf oc "Execution times:\n";


### PR DESCRIPTION
Add a boolean field in the json output called `stats-reliable`. This currently simply records whether events were lost.