### PR TITLE
[gc-stats] A test demonstrating lost events

### DIFF
--- a/test/compaction/dune
+++ b/test/compaction/dune
@@ -1,0 +1,22 @@
+(executable
+ (name test_compaction)
+ (modules test_compaction)
+ (libraries runtime_events unix))
+
+; test_compaction overflows the ring buffer, so olly must report on stderr that
+; events were lost. The count is not deterministic, hence grepping the stderr
+; rather than a cram test. Compaction is a no-op before OCaml 5.2.
+
+(rule
+ (alias runtest)
+ (package runtime_events_tools)
+ (enabled_if
+  (>= %{ocaml_version} 5.2.0))
+ (deps %{bin:olly} test_compaction.exe)
+ (action
+  (pipe-stderr
+   (setenv
+    OCAMLRUNPARAM
+    e=20,s=8M
+    (run olly gc-stats --freq=0.0 -- ./test_compaction.exe))
+   (run grep -E "^Lost [0-9]+ events, stats not reliable$"))))

--- a/test/compaction/test_compaction.ml
+++ b/test/compaction/test_compaction.ml
@@ -1,0 +1,25 @@
+module IntMap = Map.Make (Int)
+
+(* will create a map with [2^exponent] elements *)
+let exponent = 23
+let n_domains = 2
+
+let rec build i map =
+  if i <= 0 then map else IntMap.add i (Int.to_string i) map |> build (i - 1)
+
+let rec mutate i map =
+  if i <= 0 then map else IntMap.remove i map |> mutate (i - 1)
+
+let test_compaction elements n_domains =
+  Printf.eprintf "Creating map.\n%!";
+  let map = build elements IntMap.empty in
+  Printf.eprintf "Creating domains.\n%!";
+  let domains =
+    List.init n_domains (fun _ -> Domain.spawn (fun () -> mutate elements map))
+  in
+  Printf.eprintf "Compacting.\n%!";
+  Gc.full_major ();
+  Printf.eprintf "Joining domains.\n%!";
+  List.iter (fun domain -> Domain.join domain |> ignore) domains
+
+let () = test_compaction (1 lsl exponent) n_domains


### PR DESCRIPTION
A minimized test showing lost events with `olly gc-stats`. 

1. A tree map is constructed containing 2^N integers where the keys are the numbers 0 ... 2^N-1 and the values are the string representation of these numbers. 
2. Upon finishing construction, the primary domain spawns K domains, where each of these removes elements one by one from the map until the map is empty. The map is a persistent structure so there are no races, but removals continually allocate new tree nodes.
3. While the worker domains are doing the removals, the primary domain performs a full major collection.
4. The primary domain then joins the worker domains.

For N=23 and K=2 this leads to reproducible event loss on all CI platforms. 