### PR TITLE
Track explicit compactions across domains

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -24,6 +24,7 @@
   (trace (>= 0.11))
   (menhir :with-test)
   (ocamlformat (and :with-dev-setup (= 0.28.1)))
+  (yojson (and :with-test (>= 2.0)))
   (alcotest (and :with-test (>= 1.9.0)))))
 
 (package

--- a/lib/olly_gc_stats/olly_gc_stats.5.0.ml
+++ b/lib/olly_gc_stats/olly_gc_stats.5.0.ml
@@ -190,23 +190,31 @@ let gc_stats poll_sleep rss_freq json output runtime_events_dir
         true
     | _ -> false
   in
+  (* The collection counters fall into two groups, which need different
+     treatment.
+
+     [EV_MINOR] and [EV_MAJOR_GC_STW] mark global stop-the-world points, so
+     every live domain emits them once per cycle. Counting a single domain
+     index therefore yields the number of cycles rather than a per-domain
+     sum, and index 0 is the one to count because the main domain outlives
+     the others.
+
+     The [EV_EXPLICIT_GC_*] phases span a call to [Gc.compact], [Gc.major]
+     or [Gc.full_major] and are emitted only on the domain that made the
+     call, which need not be the main one. They must be counted on every
+     index or they are silently dropped. *)
   let runtime_begin ring_id ts phase =
-    if phase == Runtime_events.EV_EXPLICIT_GC_COMPACT && ring_id == 0 then
-      incr compactions;
+    if phase == Runtime_events.EV_EXPLICIT_GC_COMPACT then incr compactions;
 
     if phase == Runtime_events.EV_MINOR && ring_id == 0 then
       incr minor_collections;
 
-    (* Runtime_events.EV_MAJOR seems to correspond to any GC collection,
-       be more specific and use stop-the-world phase done at the end of
-       a major GC cycle *)
     if phase == Runtime_events.EV_MAJOR_GC_STW && ring_id == 0 then
       incr major_collections;
 
     if
-      (phase == Runtime_events.EV_EXPLICIT_GC_MAJOR
-      || phase == Runtime_events.EV_EXPLICIT_GC_FULL_MAJOR)
-      && ring_id == 0
+      phase == Runtime_events.EV_EXPLICIT_GC_MAJOR
+      || phase == Runtime_events.EV_EXPLICIT_GC_FULL_MAJOR
     then incr forced_major_collections;
 
     if is_gc_phase phase then

--- a/lib/olly_gc_stats/olly_gc_stats.5.3.ml
+++ b/lib/olly_gc_stats/olly_gc_stats.5.3.ml
@@ -262,23 +262,31 @@ let gc_stats poll_sleep rss_freq json output runtime_events_dir
         true
     | _ -> false
   in
+  (* The collection counters fall into two groups, which need different
+     treatment.
+
+     [EV_MINOR] and [EV_MAJOR_GC_STW] mark global stop-the-world points, so
+     every live domain emits them once per cycle. Counting a single domain
+     index therefore yields the number of cycles rather than a per-domain
+     sum, and index 0 is the one to count because the main domain outlives
+     the others.
+
+     The [EV_EXPLICIT_GC_*] phases span a call to [Gc.compact], [Gc.major]
+     or [Gc.full_major] and are emitted only on the domain that made the
+     call, which need not be the main one. They must be counted on every
+     index or they are silently dropped. *)
   let runtime_begin ring_id ts phase =
-    if phase == Runtime_events.EV_EXPLICIT_GC_COMPACT && ring_id == 0 then
-      incr compactions;
+    if phase == Runtime_events.EV_EXPLICIT_GC_COMPACT then incr compactions;
 
     if phase == Runtime_events.EV_MINOR && ring_id == 0 then
       incr minor_collections;
 
-    (* Runtime_events.EV_MAJOR seems to correspond to any GC collection,
-       be more specific and use stop-the-world phase done at the end of
-       a major GC cycle *)
     if phase == Runtime_events.EV_MAJOR_GC_STW && ring_id == 0 then
       incr major_collections;
 
     if
-      (phase == Runtime_events.EV_EXPLICIT_GC_MAJOR
-      || phase == Runtime_events.EV_EXPLICIT_GC_FULL_MAJOR)
-      && ring_id == 0
+      phase == Runtime_events.EV_EXPLICIT_GC_MAJOR
+      || phase == Runtime_events.EV_EXPLICIT_GC_FULL_MAJOR
     then incr forced_major_collections;
 
     if is_gc_phase phase then

--- a/runtime_events_tools.opam
+++ b/runtime_events_tools.opam
@@ -16,6 +16,7 @@ depends: [
   "trace" {>= "0.11"}
   "menhir" {with-test}
   "ocamlformat" {with-dev-setup & = "0.28.1"}
+  "yojson" {with-test & >= "2.0"}
   "alcotest" {with-test & >= "1.9.0"}
   "odoc" {with-doc}
 ]

--- a/test/dune
+++ b/test/dune
@@ -4,6 +4,16 @@
  (name test_gc_stats)
  (modules test_gc_stats))
 
+; Regression test: explicit GC calls from a non-main domain must be counted.
+; Requires 5.2, which is where the compactor landed and Gc.compact became
+; more than a no-op.
+
+(executable
+ (name test_explicit_gc)
+ (modules test_explicit_gc)
+ (enabled_if
+  (>= %{ocaml_version} 5.2.0)))
+
 (executable
  (name test_fib)
  (modules test_fib)
@@ -79,3 +89,17 @@
  (deps run_endlessly.exe)
  (action
   (run %{test} --show-errors)))
+
+(test
+ (name test_gc_counters)
+ (modules test_gc_counters)
+ (package runtime_events_tools)
+ (enabled_if
+  (>= %{ocaml_version} 5.2.0))
+ (libraries alcotest unix yojson)
+ (deps %{bin:olly} test_explicit_gc.exe)
+ (action
+  (setenv
+   OLLY_BIN
+   %{bin:olly}
+   (run %{test} --show-errors))))

--- a/test/test_explicit_gc.ml
+++ b/test/test_explicit_gc.ml
@@ -1,0 +1,19 @@
+(* Regression test: explicit GC calls made from a domain other than the main
+   one must still be counted. The EV_EXPLICIT_GC_* phases are emitted only on
+   the domain that made the call, so counting them on domain index 0 alone
+   silently reports zero here. *)
+
+let rounds = 5
+
+let work () =
+  for _ = 1 to rounds do
+    let acc = ref [] in
+    for i = 1 to 20000 do
+      acc := Array.make 8 i :: !acc
+    done;
+    ignore (Sys.opaque_identity !acc);
+    Gc.full_major ();
+    Gc.compact ()
+  done
+
+let () = Domain.join (Domain.spawn work)

--- a/test/test_gc_counters.ml
+++ b/test/test_gc_counters.ml
@@ -1,0 +1,102 @@
+(* Regression test for the collection counters reported by [olly gc-stats].
+
+   The EV_EXPLICIT_GC_* phases are emitted only on the domain that called
+   Gc.compact / Gc.major / Gc.full_major, so counting them on domain index 0
+   alone reports zero whenever the caller is not the main domain.
+
+   test_explicit_gc.exe makes five Gc.full_major and five Gc.compact calls
+   from a spawned domain, so both counters must read 5. *)
+
+let expected_calls = 5
+let workload = "./test_explicit_gc.exe"
+
+let olly_bin () =
+  match Sys.getenv_opt "OLLY_BIN" with
+  | Some p -> p
+  | None -> Alcotest.fail "OLLY_BIN is not set; the dune rule should set it"
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+
+(* Parsing rather than scanning means this also asserts that gc-stats emits
+   well-formed JSON. Yojson rejects the bare nan and inf that olly can produce
+   when a metric divides by zero, so that shows up here as a parse failure
+   rather than as a confusing counter mismatch. *)
+let parse_json ~text =
+  match Yojson.Safe.from_string text with
+  | j -> j
+  | exception Yojson.Json_error msg ->
+      Alcotest.failf "gc-stats did not emit valid JSON (%s):@\n%s" msg text
+
+let collection_count ~text json name =
+  match Yojson.Safe.Util.(json |> member "collections" |> member name) with
+  | `Int v -> v
+  | `Null ->
+      Alcotest.failf "no collections.%s field in gc-stats output:@\n%s" name
+        text
+  | other ->
+      Alcotest.failf "collections.%s is not an integer, got %s" name
+        (Yojson.Safe.to_string other)
+
+(* Run [olly gc-stats --json] over the workload, capturing stdout and stderr
+   so a failure can report what olly actually did. *)
+let run_olly ~olly ~json_out =
+  let out_file = Filename.temp_file "olly-test-stdout" ".txt" in
+  let err_file = Filename.temp_file "olly-test-stderr" ".txt" in
+  let opened path =
+    Unix.openfile path [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC ] 0o600
+  in
+  let out_fd = opened out_file and err_fd = opened err_file in
+  let pid =
+    Unix.create_process olly
+      [| olly; "gc-stats"; "--json"; "-o"; json_out; workload |]
+      Unix.stdin out_fd err_fd
+  in
+  let _, status = Unix.waitpid [] pid in
+  Unix.close out_fd;
+  Unix.close err_fd;
+  let err = read_file err_file in
+  Sys.remove out_file;
+  Sys.remove err_file;
+  (status, err)
+
+let status_to_string = function
+  | Unix.WEXITED n -> Printf.sprintf "exited with %d" n
+  | Unix.WSIGNALED n -> Printf.sprintf "killed by signal %d" n
+  | Unix.WSTOPPED n -> Printf.sprintf "stopped by signal %d" n
+
+let explicit_gc_counted () =
+  let olly = olly_bin () in
+  let json_out = Filename.temp_file "olly-gc-stats" ".json" in
+  let status, err = run_olly ~olly ~json_out in
+  (match status with
+  | Unix.WEXITED 0 -> ()
+  | s ->
+      Alcotest.failf "%s %s@\nstderr:@\n%s" olly (status_to_string s) err);
+  let text =
+    match read_file json_out with
+    | t -> t
+    | exception Sys_error msg ->
+        Alcotest.failf "could not read gc-stats json output: %s@\nstderr:@\n%s"
+          msg err
+  in
+  Sys.remove json_out;
+  let json = parse_json ~text in
+  Alcotest.(check int)
+    "compactions from a non-main domain" expected_calls
+    (collection_count ~text json "compactions");
+  Alcotest.(check int)
+    "forced major collections from a non-main domain" expected_calls
+    (collection_count ~text json "forced_major")
+
+let () =
+  let open Alcotest in
+  run "GC counters"
+    [
+      ( "collections",
+        [ test_case "explicit GC from a spawned domain" `Quick explicit_gc_counted ]
+      );
+    ]


### PR DESCRIPTION
The [EV_EXPLICIT_GC_*] phases span a call to [Gc.compact], [Gc.major] or [Gc.full_major] and are emitted only on the domain that made the call, which need not be the main one. They must be counted on every index or they are silently dropped.