### PR TITLE
Fix spelling of stats_reliable field

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,55 +38,55 @@ output and omitted from the human-readable output.
 ```bash
 $ olly gc-stats './test_gc_stats.exe 18' # Use quotes for commands with arguments
 Execution times:
-Wall time (s):	0.52
-CPU time (s):	1.47
-GC time (s):	0.62
-GC overhead (% of CPU time):	41.98%
-Max RSS (kB):	65840
+Wall time (s):	0.54
+CPU time (s):	1.52
+GC time (s):	0.65
+GC overhead (% of CPU time):	42.91%
+Max RSS (kB):	64448
 
-Per domain stats:
+Per domain time:
 Domain   Wall   GC(s)   GC(%)  
-0        0.52   0.24    45.12  
-1        0.49   0.21    42.19  
-2        0.46   0.17    38.17  
+0        0.54   0.24    43.79  
+1        0.48   0.20    40.98  
+2        0.51   0.22    43.80  
 
 GC latency profile:
-#[Mean (ms):	0.23,	 Stddev (ms):	0.53]
-#[Min (ms):	0.00,	 max (ms):	4.71]
+#[Mean (ms):	0.24,	 Stddev (ms):	0.53]
+#[Min (ms):	0.00,	 max (ms):	4.14]
 
 Percentile 	 Latency (ms)
 25.0000 	 0.00
 50.0000 	 0.01
-60.0000 	 0.01
+60.0000 	 0.02
 70.0000 	 0.05
-75.0000 	 0.13
-80.0000 	 0.24
-85.0000 	 0.55
-90.0000 	 0.89
-95.0000 	 1.29
-96.0000 	 1.39
-97.0000 	 1.51
-98.0000 	 2.11
-99.0000 	 2.74
-99.9000 	 3.57
-99.9900 	 4.71
-99.9990 	 4.71
-99.9999 	 4.71
-100.0000 	 4.71
+75.0000 	 0.14
+80.0000 	 0.28
+85.0000 	 0.58
+90.0000 	 0.98
+95.0000 	 1.31
+96.0000 	 1.38
+97.0000 	 1.56
+98.0000 	 2.25
+99.0000 	 2.72
+99.9000 	 3.35
+99.9900 	 4.14
+99.9990 	 4.14
+99.9999 	 4.14
+100.0000 	 4.14
 
 GC allocations (in words): 
-Total heap:	 295711855
-Minor heap:	 301109826
-Major heap:	 45017730
-Promoted words:	 50415701 (16.74%)
+Total heap:	 296241054
+Minor heap:	 301205191
+Major heap:	 46112581
+Promoted words:	 51076718 (16.96%)
 
-Per domain stats: 
-Domain   Total      Minor       Promoted   Major      Promoted(%)  
-0        99721155   101879432   18727340   16569063   18.38        
-1        97590020   99615197    16072386   14047209   16.13        
-2        98400680   99615197    15615975   14401458   15.68        
-Minor Gen: 461 collections
-Major Gen: 40 collections 0 forced collections
+Per domain allocations:
+Domain   Total       Minor       Promoted   Major      Promoted(%)  
+0        100222337   101974797   17913651   16161191   17.57        
+1        97996796    99615197    16575682   14957281   16.64        
+2        98021921    99615197    16587385   14994109   16.65        
+Minor Gen: 467 collections
+Major Gen: 41 collections 0 forced collections
 Compactions: 0
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,68 +14,79 @@ The main tool is called `olly`, it provides a number of sub-commands for gatheri
 
 Running `olly gc-stats` will report the GC running time and GC tail latency profile of an OCaml executable.
 
-| Metric             | Description                                                                        |
-|--------------------|------------------------------------------------------------------------------------|
-| Wall time          | Real execution time of the program                                                 |
-| CPU time           | Total CPU time across all domains                                                  |
-| GC time            | Total time spent by the program performing garbage collection (major and minor)    |
-| GC overhead        | Percentage of time taken up by GC against the total execution time                 |
-| GC time per domain | Time spent by every domain performing garbage collection (major and minor cycles). |
-| GC latency profile | Mean, standard deviation and percentile latency profile of GC events.              |
+| Metric                 | Description                                                                        |
+|------------------------|------------------------------------------------------------------------------------|
+| Wall time              | Real execution time of the program                                                 |
+| CPU time               | Total CPU time across all domains                                                  |
+| GC time                | Total time spent by the program performing garbage collection (major and minor)    |
+| GC overhead            | Percentage of time taken up by GC against the total execution time                 |
+| Max RSS                | Peak resident set size of the traced process, sampled during execution             |
+| GC time per domain     | Time spent by every domain performing garbage collection (major and minor cycles). |
+| GC latency profile     | Mean, standard deviation and percentile latency profile of GC events.              |
+| GC allocations         | Words allocated and promoted over the run, in total and per domain                 |
+| Collections            | Counts of minor and major collections, forced collections and compactions          |
 
 Note: all times are wall-clock and so include time spent blocking.
 
+Note: the allocation figures are cumulative totals for the whole run, not heap
+sizes. `Minor heap` is every word allocated in the minor heap, `Major heap` is
+every word that reached the major heap whether by promotion or by direct
+allocation, and `Total heap` is the two combined with the promoted words counted
+once. Values that a given OCaml version cannot report are `null` in the JSON
+output and omitted from the human-readable output.
+
 ```bash
-$ olly gc-stats 'EXECUTABLE' # Use quotes for commands with arguments
+$ olly gc-stats './test_gc_stats.exe 18' # Use quotes for commands with arguments
 Execution times:
-Wall time (s):  114.15
-CPU time (s):   1012.84
-GC time (s):    173.08
-GC overhead (% of CPU time):    17.09%
+Wall time (s):	0.52
+CPU time (s):	1.47
+GC time (s):	0.62
+GC overhead (% of CPU time):	41.98%
+Max RSS (kB):	65840
 
 Per domain stats:
-Domain   Wall(s)         GC(s)   GC(%)
-0        114.15          11.52   10.10
-1        112.19          20.00   17.83
-2        112.19          20.64   18.40
-3        112.21          20.20   18.01
-4        112.19          20.33   18.12
-5        112.28          19.91   17.73
-6        112.20          20.32   18.11
-7        112.87          19.75   17.49
-8        112.57          20.41   18.13
+Domain   Wall   GC(s)   GC(%)  
+0        0.52   0.24    45.12  
+1        0.49   0.21    42.19  
+2        0.46   0.17    38.17  
 
 GC latency profile:
-#[Mean (ms):    4.95,    Stddev (ms):   5.58]
-#[Min (ms):     0.00,    max (ms):      72.55]
+#[Mean (ms):	0.23,	 Stddev (ms):	0.53]
+#[Min (ms):	0.00,	 max (ms):	4.71]
 
-Percentile       Latency (ms)
-25.0000          0.05
-50.0000          4.66
-60.0000          5.51
-70.0000          6.38
-75.0000          6.89
-80.0000          7.54
-85.0000          8.54
-90.0000          10.56
-95.0000          14.58
-96.0000          16.27
-97.0000          18.14
-98.0000          21.10
-99.0000          26.62
-99.9000          47.19
-99.9900          66.98
-99.9990          72.55
-99.9999          72.55
-100.0000         72.55
+Percentile 	 Latency (ms)
+25.0000 	 0.00
+50.0000 	 0.01
+60.0000 	 0.01
+70.0000 	 0.05
+75.0000 	 0.13
+80.0000 	 0.24
+85.0000 	 0.55
+90.0000 	 0.89
+95.0000 	 1.29
+96.0000 	 1.39
+97.0000 	 1.51
+98.0000 	 2.11
+99.0000 	 2.74
+99.9000 	 3.57
+99.9900 	 4.71
+99.9990 	 4.71
+99.9999 	 4.71
+100.0000 	 4.71
 
-GC allocations (in words):
-Total heap:	 501516808
-Minor heap:	 602373895
-Promoted words:	 100857087 (16.74%)
+GC allocations (in words): 
+Total heap:	 295711855
+Minor heap:	 301109826
+Major heap:	 45017730
+Promoted words:	 50415701 (16.74%)
 
-Minor Gen: 904 collections
-Major Gen: 34 collections 0 forced collections
+Per domain stats: 
+Domain   Total      Minor       Promoted   Major      Promoted(%)  
+0        99721155   101879432   18727340   16569063   18.38        
+1        97590020   99615197    16072386   14047209   16.13        
+2        98400680   99615197    15615975   14401458   15.68        
+Minor Gen: 461 collections
+Major Gen: 40 collections 0 forced collections
 Compactions: 0
 ```
 

--- a/lib/olly_gc_stats/olly_gc_stats.5.0.ml
+++ b/lib/olly_gc_stats/olly_gc_stats.5.0.ml
@@ -110,7 +110,7 @@ let print_percentiles json output hist outliers =
     "forced_major": %i,       
     "compactions": %i
   },       
-  "stats-reliable": %b
+  "stats_reliable": %b
 }|}
       real_time !total_cpu_time total_gc_time gc_overhead
       (Olly_common.Max_rss.max_rss_kb rss_collector)

--- a/lib/olly_gc_stats/olly_gc_stats.5.0.ml
+++ b/lib/olly_gc_stats/olly_gc_stats.5.0.ml
@@ -51,7 +51,6 @@ let print_percentiles json output hist outliers =
       promoted_words :=
         !promoted_words +. float_of_int domain_promoted_words.(i))
     domain_minor_words;
-  let total_heap = !minor_words -. !promoted_words in
   let promoted_pct = !promoted_words /. !minor_words *. 100.0 in
 
   if json then
@@ -172,7 +171,6 @@ let print_percentiles json output hist outliers =
         (float_of_int outliers.max |> ms);
     Printf.fprintf oc "\n";
     Printf.fprintf oc "GC allocations (in words): \n";
-    Printf.fprintf oc "Total heap:\t %.0f\n" total_heap;
     Printf.fprintf oc "Minor heap:\t %.0f\n" !minor_words;
     Printf.fprintf oc "Promoted words:\t %.0f (%.2f%%)\n" !promoted_words
       promoted_pct;

--- a/lib/olly_gc_stats/olly_gc_stats.5.0.ml
+++ b/lib/olly_gc_stats/olly_gc_stats.5.0.ml
@@ -101,7 +101,7 @@ let print_percentiles json output hist outliers =
     "max_latency": %f
   },       
   "allocations": {       
-    "total_heap": %.0f,       
+    "total_heap": null,       
     "minor_heap": %.0f,       
     "major_heap": null,       
     "promoted_words": %.0f,       
@@ -121,7 +121,7 @@ let print_percentiles json output hist outliers =
       domain_stats mean_latency stddev_latency min_latency max_latency distribs
       outliers.count outlier_mean_ms
       (float_of_int outliers.max |> ms)
-      total_heap !minor_words !promoted_words promoted_pct !minor_collections
+      !minor_words !promoted_words promoted_pct !minor_collections
       !major_collections !forced_major_collections !compactions
       (not @@ Olly_common.Launch.Lost_events.were_events_lost ())
   else (

--- a/lib/olly_gc_stats/olly_gc_stats.5.0.ml
+++ b/lib/olly_gc_stats/olly_gc_stats.5.0.ml
@@ -79,6 +79,8 @@ let print_percentiles json output hist outliers =
         (Array.combine domain_elapsed_times domain_gc_times);
       Buffer.contents buf
     in
+    (* Key set matches the 5.3 backend. Fields this runtime cannot report
+       are null. *)
     Printf.fprintf oc
       {|{       
   "version": 2,       
@@ -101,9 +103,11 @@ let print_percentiles json output hist outliers =
   "allocations": {       
     "total_heap": %.0f,       
     "minor_heap": %.0f,       
+    "major_heap": null,       
     "promoted_words": %.0f,       
     "promoted_pct": %.2f
   },       
+  "domain_alloc_stats": null,       
   "collections": {       
     "minor": %i,       
     "major": %i,       

--- a/lib/olly_gc_stats/olly_gc_stats.5.0.ml
+++ b/lib/olly_gc_stats/olly_gc_stats.5.0.ml
@@ -133,7 +133,7 @@ let print_percentiles json output hist outliers =
     Printf.fprintf oc "Max RSS (kB):\t%d\n"
       (Olly_common.Max_rss.max_rss_kb rss_collector);
     Printf.fprintf oc "\n";
-    Printf.fprintf oc "Per domain stats:\n";
+    Printf.fprintf oc "Per domain time:\n";
     let data = ref [ [ "Domain"; "Wall"; "GC(s)"; "GC(%)" ] ] in
     Array.iteri
       (fun i (c, g) ->

--- a/lib/olly_gc_stats/olly_gc_stats.5.3.ml
+++ b/lib/olly_gc_stats/olly_gc_stats.5.3.ml
@@ -14,7 +14,6 @@ let print_global_allocation_stats oc =
       promoted_words :=
         !promoted_words +. float_of_int domain_promoted_words.(i))
     domain_minor_words;
-  Printf.fprintf oc "Total heap:\t %.0f\n" (!minor_words -. !promoted_words);
   Printf.fprintf oc "Total heap:\t %.0f\n"
     (!minor_words -. !promoted_words +. !major_words);
   Printf.fprintf oc "Minor heap:\t %.0f\n" !minor_words;

--- a/lib/olly_gc_stats/olly_gc_stats.5.3.ml
+++ b/lib/olly_gc_stats/olly_gc_stats.5.3.ml
@@ -23,7 +23,7 @@ let print_global_allocation_stats oc =
   Printf.fprintf oc "\n"
 
 let print_per_domain_stats oc =
-  Printf.fprintf oc "Per domain stats: \n";
+  Printf.fprintf oc "Per domain allocations:\n";
   let data =
     ref [ [ "Domain"; "Total"; "Minor"; "Promoted"; "Major"; "Promoted(%)" ] ]
   in
@@ -205,7 +205,7 @@ let print_percentiles json output hist outliers =
     Printf.fprintf oc "Max RSS (kB):\t%d\n"
       (Olly_common.Max_rss.max_rss_kb rss_collector);
     Printf.fprintf oc "\n";
-    Printf.fprintf oc "Per domain stats:\n";
+    Printf.fprintf oc "Per domain time:\n";
     let data = ref [ [ "Domain"; "Wall"; "GC(s)"; "GC(%)" ] ] in
     Array.iteri
       (fun i (c, g) ->


### PR DESCRIPTION
We consistently use snake_case elsewhere in this project See https://github.com/tarides/runtime_events_tools/blob/main/lib/olly_gc_stats/olly_gc_stats.5.3.ml#L188