### PR TITLE
Document what --emit-counters emits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 ### Unreleased
+* Document what `--emit-counters` emits, linking to the runtime tracing manual
+  and the `Runtime_events` API reference (#123, @tmcgilchrist)
 * Check process status from a dedicated domain (#100, @ngorogiannis)
 * gc-stats no longer prints a (zeroed) stats block when the run fails; it now reports only the error (#100, @ngorogiannis)
 * Wait for the traced process to initialise its ring buffers (@ngorogiannis)

--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ or
 [Chrome tracing format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview)
 . The trace format can be specified with the `--format` option, with the default being Fuchsia trace format.
 
+Passing `--emit-counters` additionally records the runtime's counter events,
+such as major heap occupancy and GC pacing. Every counter defined by the OCaml
+runtime in use is emitted, so the set varies by OCaml version; see the
+[runtime tracing](https://ocaml.org/manual/runtime-tracing.html) documentation
+and the [`Runtime_events`](https://ocaml.org/manual/latest/api/Runtime_events.html)
+API reference for what each one measures.
+
 ```bash
 $ olly trace --format=fuchsia menhir_sysver.trace 'menhir -v --table sysver.mly' # Fuchsia trace format
 <snip>

--- a/lib/olly_trace/olly_trace.ml
+++ b/lib/olly_trace/olly_trace.ml
@@ -59,7 +59,13 @@ let trace_cmd format_list =
   in
 
   let emit_counter =
-    let doc = "Emit runtime counter events." in
+    let doc =
+      "Emit runtime counter events. All counters defined by the OCaml runtime \
+       in use are emitted, so the set varies by OCaml version. See \
+       https://ocaml.org/manual/runtime-tracing.html and \
+       https://ocaml.org/manual/latest/api/Runtime_events.html for what each \
+       counter measures."
+    in
     Arg.(value & flag & info [ "c"; "emit-counters" ] ~doc)
   in
 

--- a/test/cram/olly.t
+++ b/test/cram/olly.t
@@ -59,7 +59,11 @@ Trace subcommand help:
              combined with EXECUTABLE.
   
          -c, --emit-counters
-             Emit runtime counter events.
+             Emit runtime counter events. All counters defined by the OCaml
+             runtime in use are emitted, so the set varies by OCaml version.
+             See https://ocaml.org/manual/runtime-tracing.html and
+             https://ocaml.org/manual/latest/api/Runtime_events.html for what
+             each counter measures.
   
          -d dir, --dir=dir
              Sets the directory where the .events files containing the runtime


### PR DESCRIPTION
It emits every counter the runtime defines, so the set varies by OCaml version. Point at the runtime tracing docs rather than listing them here.