### PR TITLE
Report words losts, not events

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 ### Unreleased
+* Report lost words, not events (#126, @ngorogiannis) 
 * Count explicit GC calls (`Gc.compact`, `Gc.major`, `Gc.full_major`) made by any
   domain, not just the main one (#115, @ngorogiannis)
 * Check process status from a dedicated domain (#100, @ngorogiannis)

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Traces in either formats can be viewed in [perfetto trace viewer](https://ui.per
 
 ## Missed events
 
-If olly does not read a domain's ring buffer fast enough then some events will be lost, which is reported as `[ring_id=6] Lost 1584944 events`. If this occurs the results from olly *may* be inaccurate. There are several ways to fix this:
+If olly does not read a domain's ring buffer fast enough then some events will be lost, which is reported as `[ring_id=6] Lost 1584944 ring buffer words, stats not reliable`. If this occurs the results from olly *may* be inaccurate. There are several ways to fix this:
 
 1. Use `--freq` option to make olly read the ring buffer more frequently.
 2. Set `OCAMLRUNPARAM=e=20` to increase the size of the ring buffer.

--- a/lib/olly_common/launch.ml
+++ b/lib/olly_common/launch.ml
@@ -1,20 +1,20 @@
 external is_process_alive : int -> bool = "olly_is_process_alive"
 
 module Lost_events = struct
-  let lost_events_count = ref 0
+  let lost_words_count = ref 0
 
   let callback _ring_id num =
-    let sum = !lost_events_count + num in
+    let sum = !lost_words_count + num in
     (* detect overflow and stay at [max_int] *)
-    lost_events_count := if sum < 0 then max_int else sum
+    lost_words_count := if sum < 0 then max_int else sum
 
-  let were_events_lost () = !lost_events_count > 0
+  let were_events_lost () = !lost_words_count > 0
 
   let display () =
     if were_events_lost () then begin
-      Printf.eprintf "Lost %d events, stats not reliable%s\n%!"
-        !lost_events_count
-        (if !lost_events_count = max_int then
+      Printf.eprintf "Lost %d ring buffer words, stats not reliable%s\n%!"
+        !lost_words_count
+        (if !lost_words_count = max_int then
            " (possible counter overflow detected)\n%!"
          else "")
     end


### PR DESCRIPTION
The runtime reports words lost, not events. This diff fixes the naming of variables and the console output.

Addresses https://github.com/tarides/runtime_events_tools/issues/118