### PR TITLE
Propagate exit codes from child processes

### DIFF
--- a/lib/olly_common/dune
+++ b/lib/olly_common/dune
@@ -1,6 +1,7 @@
 (library
  (name olly_common)
  (libraries runtime_events unix cmdliner)
+ (modules cli launch process_poller sys_backport)
  (foreign_stubs
   (language c)
   (names process_utils max_rss_stubs)))
@@ -16,3 +17,15 @@
   (< %{ocaml_version} 5.1.0))
  (action
   (copy process_poller_5.0.ml process_poller.ml)))
+
+(rule
+ (enabled_if
+  (< %{ocaml_version} 5.4.0))
+ (action
+  (copy# sys_backport_from_5.4.ml sys_backport.ml)))
+
+(rule
+ (enabled_if
+  (>= %{ocaml_version} 5.4.0))
+ (action
+  (copy# sys_alias.ml sys_backport.ml)))

--- a/lib/olly_common/launch.ml
+++ b/lib/olly_common/launch.ml
@@ -24,6 +24,7 @@ type subprocess = {
   alive : unit -> bool;
   cursor : Runtime_events.cursor;
   close : unit -> unit;
+  exit_status : unit -> Unix.process_status option;
   pid : int;
 }
 
@@ -114,6 +115,15 @@ let create_cursor_when_ready ~dir ~pid ~executable =
   in
   wait ()
 
+let str_of_status status =
+  let open Sys_backport in
+  match status with
+  | Unix.WEXITED code -> Printf.sprintf "exited with code %d" code
+  | Unix.WSIGNALED sys_sig ->
+      Printf.sprintf "killed by signal %s" (signal_to_string sys_sig)
+  | Unix.WSTOPPED sys_sig ->
+      Printf.sprintf "stopped by signal %s" (signal_to_string sys_sig)
+
 let exec_process (config : runtime_events_config) (args : string list) :
     subprocess =
   if not (List.length args > 0) then
@@ -180,18 +190,20 @@ let exec_process (config : runtime_events_config) (args : string list) :
     create_cursor_when_ready ~dir ~pid:child_pid ~executable:executable_filename
   in
   (* used to avoid double reaping, which raises an exception other than ECHILD on windows *)
-  let reaped = Atomic.make false in
+  let reaped = Atomic.make None in
   let alive () =
     match Unix.waitpid [ Unix.WNOHANG ] child_pid with
     | 0, _ -> true
-    | p, _ when p = child_pid ->
-        Atomic.set reaped true;
+    | p, status when p = child_pid ->
+        Atomic.set reaped (Some status);
         false
     | _, _ -> assert false
     | exception Unix.Unix_error (Unix.EINTR, _, _) -> true
   and close () =
-    (if not @@ Atomic.get reaped then
-       try Unix.waitpid [ WNOHANG ] child_pid |> ignore
+    (if Option.is_none @@ Atomic.get reaped then
+       try
+         let _, status = Unix.waitpid [ WNOHANG ] child_pid in
+         Atomic.set reaped (Some status)
        with Unix.Unix_error (Unix.ECHILD, _, _) -> ());
     Runtime_events.free_cursor cursor;
     (* We need to remove the ring buffers ourselves because we told
@@ -200,8 +212,8 @@ let exec_process (config : runtime_events_config) (args : string list) :
        their intent and leave the file in place. *)
     if Sys.getenv_opt "OCAML_RUNTIME_EVENTS_PRESERVE" <> Some "1" then
       Unix.unlink (ring_file_of dir child_pid)
-  in
-  { alive; cursor; close; pid = child_pid }
+  and exit_status () = Atomic.get reaped in
+  { alive; cursor; close; pid = child_pid; exit_status }
 
 let attach_process (dir : string) (pid : int) : subprocess =
   (* Check the target process exists before attempting to attach *)
@@ -227,8 +239,9 @@ let attach_process (dir : string) (pid : int) : subprocess =
     with Failure str -> raise (Fail (str ^ " Directory: " ^ dir))
   in
   let alive () = is_process_alive pid
+  and exit_status () = None
   and close () = Runtime_events.free_cursor cursor in
-  { alive; cursor; close; pid }
+  { alive; cursor; close; pid; exit_status }
 
 let launch_process config (exec_args : exec_config) : subprocess =
   match exec_args with
@@ -326,4 +339,9 @@ let olly config exec_args =
           in
           collect_events ~sample_rss:config.sample_rss
             config.process_poller_sleep config.poll_sleep child callbacks;
-          config.on_success ()))
+          config.on_success ());
+      child.exit_status ()
+      |> Option.iter @@ function
+         | Unix.WEXITED 0 -> ()
+         | status ->
+             raise (Fail (Printf.sprintf "Child %s" @@ str_of_status status)))

--- a/lib/olly_common/sys_alias.ml
+++ b/lib/olly_common/sys_alias.ml
@@ -1,0 +1,1 @@
+let signal_to_string = Sys.signal_to_string

--- a/lib/olly_common/sys_backport.mli
+++ b/lib/olly_common/sys_backport.mli
@@ -1,0 +1,1 @@
+val signal_to_string : int -> string

--- a/lib/olly_common/sys_backport_from_5.4.ml
+++ b/lib/olly_common/sys_backport_from_5.4.ml
@@ -1,0 +1,46 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+open Sys
+
+let signal_to_string s =
+  if s = sigabrt then "SIGABRT"
+  else if s = sigalrm then "SIGALRM"
+  else if s = sigfpe then "SIGFPE"
+  else if s = sighup then "SIGHUP"
+  else if s = sigill then "SIGILL"
+  else if s = sigint then "SIGINT"
+  else if s = sigkill then "SIGKILL"
+  else if s = sigpipe then "SIGPIPE"
+  else if s = sigquit then "SIGQUIT"
+  else if s = sigsegv then "SIGSEGV"
+  else if s = sigterm then "SIGTERM"
+  else if s = sigusr1 then "SIGUSR1"
+  else if s = sigusr2 then "SIGUSR2"
+  else if s = sigchld then "SIGCHLD"
+  else if s = sigcont then "SIGCONT"
+  else if s = sigstop then "SIGSTOP"
+  else if s = sigtstp then "SIGTSTP"
+  else if s = sigttin then "SIGTTIN"
+  else if s = sigttou then "SIGTTOU"
+  else if s = sigvtalrm then "SIGVTALRM"
+  else if s = sigprof then "SIGPROF"
+  else if s = sigbus then "SIGBUS"
+  else if s = sigpoll then "SIGPOLL"
+  else if s = sigsys then "SIGSYS"
+  else if s = sigtrap then "SIGTRAP"
+  else if s = sigurg then "SIGURG"
+  else if s = sigxcpu then "SIGXCPU"
+  else if s = sigxfsz then "SIGXFSZ"
+  else "SIG(" ^ string_of_int s ^ ")"

--- a/test/cram/dune
+++ b/test/cram/dune
@@ -1,3 +1,7 @@
 (cram
  (package runtime_events_tools)
- (deps %{bin:olly} %{dep:../test_gc_stats.exe}))
+ (deps
+  %{bin:olly}
+  %{dep:../test_gc_stats.exe}
+  %{dep:../run_exit.exe}
+  %{dep:../run_crash.exe}))

--- a/test/cram/exitcodes.t
+++ b/test/cram/exitcodes.t
@@ -1,0 +1,12 @@
+Olly exits with code 0 when the launched OCaml program succeeds:
+  $ olly latency -o t1.out ../run_exit.exe
+
+Olly exits with non-zero code when the launched OCaml program fails:
+  $ olly latency -o t2.out ../run_exit.exe 42
+  olly: Child exited with code 42
+  [124]
+
+Olly exits with non-zero code when the launched OCaml program crashes:
+  $ olly latency -o t3.out ../run_crash.exe
+  olly: Child killed by signal SIGKILL
+  [124]

--- a/test/dune
+++ b/test/dune
@@ -69,6 +69,15 @@
  (modules run_endlessly)
  (libraries unix))
 
+(executables
+ (names run_exit)
+ (modules run_exit))
+
+(executables
+ (names run_crash)
+ (modules run_crash)
+ (libraries unix))
+
 (test
  (name test_launch)
  (modules test_launch)

--- a/test/run_crash.ml
+++ b/test/run_crash.ml
@@ -1,0 +1,1 @@
+let () = Unix.kill (Unix.getpid ()) Sys.sigkill

--- a/test/run_exit.ml
+++ b/test/run_exit.ml
@@ -1,0 +1,1 @@
+let () = if Array.length Sys.argv > 1 then Sys.argv.(1) |> int_of_string |> exit


### PR DESCRIPTION
```
Olly exits with non-zero code when the launched OCaml program fails:
  $ olly latency -o t2.out ../run_nonzero.exe
  olly: Child exited with code 42
  [124]

Olly exits with non-zero code when the launched OCaml program crashes:
  $ olly latency -o t3.out ../run_crash.exe
  olly: Child killed by signal SIGKILL
  [124]
```

124 isn't quite the right exitcode (`--help` says `124 on command line parsing errors.`), but fixing consistently is probably better done in another PR (I've opened https://github.com/tarides/runtime_events_tools/issues/129)