### PR TITLE
[windows] ensure lf line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.opam text eol=lf


### PR DESCRIPTION
On Windows, if the git attribute `core.autocrlf` is `true` (the default), then `dune build` will regerenate `opam` files but with `lf` line endings, leading to an unclean repo state even though the text is the same.

This can be fixed per-repo via a .gitattributes setting which is what is added here.