### PR TITLE
[windows] fix test_launch

### DIFF
--- a/lib/olly_common/dune
+++ b/lib/olly_common/dune
@@ -1,7 +1,7 @@
 (library
  (name olly_common)
  (libraries runtime_events unix cmdliner)
- (modules cli launch process_poller sys_backport)
+ (modules cli launch platform process_poller sys_backport)
  (foreign_stubs
   (language c)
   (names process_utils max_rss_stubs)))

--- a/lib/olly_common/launch.ml
+++ b/lib/olly_common/launch.ml
@@ -1,5 +1,3 @@
-external is_process_alive : int -> bool = "olly_is_process_alive"
-
 module Lost_events = struct
   let lost_words_count = ref 0
 
@@ -20,13 +18,29 @@ module Lost_events = struct
     end
 end
 
+(* Where the process we are tracing came from. The two cases genuinely differ:
+   we own a child we launched and can wait on it, whereas an attached process
+   is somebody else's, so there is no status of it for us to collect. *)
+type origin =
+  | Launched of { reaped : Unix.process_status option Atomic.t }
+  | Attached
+
 type subprocess = {
   alive : unit -> bool;
   cursor : Runtime_events.cursor;
   close : unit -> unit;
-  exit_status : unit -> Unix.process_status option;
+  origin : origin;
   pid : int;
 }
+
+(* The child's own exit status, once it has been collected. [None] means "not
+   yet known" for a launched process and "never knowable" for an attached one,
+   and also covers a child that [close] had to terminate: a status we
+   manufactured by killing it is not the child's own. *)
+let exit_status t =
+  match t.origin with
+  | Launched { reaped } -> Atomic.get reaped
+  | Attached -> None
 
 type runtime_events_config = { log_wsize : int option; dir : string option }
 type exec_config = Attach of string * int | Execute of string list
@@ -46,7 +60,9 @@ exception Fail of string
    we poll instead. *)
 let ring_wait_timeout = 5.0
 let ring_wait_interval = 0.005
-let ring_file_of dir pid = Filename.concat dir (string_of_int pid ^ ".events")
+
+let ring_file_of_pid dir pid =
+  Filename.concat dir (string_of_int pid ^ ".events")
 
 (* The runtime creates the ring file, then resizes it to its final size, then
    fills in the metadata header (see [runtime/runtime_events.c] in the OCaml
@@ -69,15 +85,16 @@ let ring_header_ready ring_file =
               Bytes.get_int64_ne buf 0 <> 0L && Bytes.get_int64_ne buf 8 <> 0L
           | exception End_of_file -> false)
 
-(* Wait for the child process [pid] to initialise its ring buffers and return
+(* Wait for the child process [handle] to initialise its ring buffers and return
    a cursor on them. Raises [Fail] if the child dies first, or if it has not
    initialised them within [ring_wait_timeout]. *)
-let create_cursor_when_ready ~dir ~pid ~executable =
-  let ring_file = ring_file_of dir pid in
+let create_cursor_when_ready ~dir ~pid ~(handle : Platform.handle) ~executable =
+  let ring_file = ring_file_of_pid dir pid in
   let deadline = Unix.gettimeofday () +. ring_wait_timeout in
   let child_exited () =
-    match Unix.waitpid [ Unix.WNOHANG ] pid with
-    | p, _ -> p = pid
+    match Platform.waitpid [ Unix.WNOHANG ] handle with
+    | None -> false
+    | Some _ -> true
     | exception Unix.Unix_error (Unix.EINTR, _, _) -> false
   in
   let rec wait () =
@@ -97,8 +114,7 @@ let create_cursor_when_ready ~dir ~pid ~executable =
     else if Unix.gettimeofday () >= deadline then begin
       (* We cannot monitor the child and are about to bail out, so do not
          leave it running behind us. *)
-      (try Unix.kill pid Sys.sigkill with Unix.Unix_error _ -> ());
-      (try ignore (Unix.waitpid [] pid) with Unix.Unix_error _ -> ());
+      ignore (Platform.terminate_and_reap handle);
       raise
         (Fail
            (Printf.sprintf
@@ -178,49 +194,77 @@ let exec_process (config : runtime_events_config) (args : string list) :
         base_env;
       ]
   in
-  let child_pid =
-    try
-      Unix.create_process_env executable_filename (Array.of_list args) env
-        Unix.stdin Unix.stdout Unix.stderr
-    with Unix.Unix_error (Unix.ENOENT, _, _) ->
-      raise
-        (Fail (Printf.sprintf "executable %s not found" executable_filename))
+  let child_pid, child_handle =
+    let handle =
+      try
+        Platform.create_process_env executable_filename (Array.of_list args) env
+          Unix.stdin Unix.stdout Unix.stderr
+      with Unix.Unix_error (Unix.ENOENT, _, _) ->
+        raise
+          (Fail (Printf.sprintf "executable %s not found" executable_filename))
+    in
+    let pid =
+      try Platform.pid_of_handle handle
+      with Unix.Unix_error (err, fn, _) ->
+        raise
+          (Fail
+             (Printf.sprintf "cannot determine the pid of %s: %s: %s"
+                executable_filename fn (Unix.error_message err)))
+    in
+    (pid, handle)
   in
   let cursor =
-    create_cursor_when_ready ~dir ~pid:child_pid ~executable:executable_filename
+    create_cursor_when_ready ~dir ~pid:child_pid ~handle:child_handle
+      ~executable:executable_filename
   in
   (* used to avoid double reaping, which raises an exception other than ECHILD on windows *)
   let reaped = Atomic.make None in
   let alive () =
-    match Unix.waitpid [ Unix.WNOHANG ] child_pid with
-    | 0, _ -> true
-    | p, status when p = child_pid ->
-        Atomic.set reaped (Some status);
-        false
-    | _, _ -> assert false
-    | exception Unix.Unix_error (Unix.EINTR, _, _) -> true
+    (* on Windows, [waitpid] will fail if the process has been reaped *)
+    if Option.is_some @@ Atomic.get reaped then false
+    else
+      match Platform.waitpid [ Unix.WNOHANG ] child_handle with
+      | None -> true
+      | Some _ as some_status ->
+          Atomic.set reaped some_status;
+          false
+      | exception Unix.Unix_error (Unix.EINTR, _, _) -> true
   and close () =
-    (if Option.is_none @@ Atomic.get reaped then
-       try
-         let _, status = Unix.waitpid [ WNOHANG ] child_pid in
-         Atomic.set reaped (Some status)
-       with Unix.Unix_error (Unix.ECHILD, _, _) -> ());
+    let orphaned =
+      if Option.is_some @@ Atomic.get reaped then false
+      else
+        match Platform.waitpid [ Unix.WNOHANG ] child_handle with
+        | Some status ->
+            Atomic.set reaped (Some status);
+            false
+        | None ->
+            (* The child is still running. Do not leave it behind us, and note
+               that the ring file stays mapped, and so cannot be unlinked on
+               Windows, for as long as it lives. *)
+            not (Platform.terminate_and_reap child_handle)
+        | exception Unix.Unix_error (Unix.ECHILD, _, _) -> false
+    in
     Runtime_events.free_cursor cursor;
     (* We need to remove the ring buffers ourselves because we told
        the child process not to remove them. However, if the user
        explicitly set OCAML_RUNTIME_EVENTS_PRESERVE=1 we honour
        their intent and leave the file in place. *)
     if Sys.getenv_opt "OCAML_RUNTIME_EVENTS_PRESERVE" <> Some "1" then
-      Unix.unlink (ring_file_of dir child_pid)
-  and exit_status () = Atomic.get reaped in
-  { alive; cursor; close; pid = child_pid; exit_status }
+      if orphaned then
+        Printf.eprintf
+          "warning: could not terminate child %d, leaving %s behind\n%!"
+          child_pid
+          (ring_file_of_pid dir child_pid)
+      else Unix.unlink (ring_file_of_pid dir child_pid)
+  in
+  { alive; cursor; close; origin = Launched { reaped }; pid = child_pid }
 
 let attach_process (dir : string) (pid : int) : subprocess =
   (* Check the target process exists before attempting to attach *)
-  if not (is_process_alive pid) then
+  if not (Platform.is_process_alive ~pid) then
     raise (Fail (Printf.sprintf "process %d does not exist" pid));
   (* Check the events file exists and is readable *)
-  let ring_file = ring_file_of dir pid in
+  let ring_file = ring_file_of_pid dir pid in
   if not (Sys.file_exists ring_file) then
     raise
       (Fail
@@ -238,10 +282,9 @@ let attach_process (dir : string) (pid : int) : subprocess =
     try Runtime_events.create_cursor (Some (dir, pid))
     with Failure str -> raise (Fail (str ^ " Directory: " ^ dir))
   in
-  let alive () = is_process_alive pid
-  and exit_status () = None
+  let alive () = Platform.is_process_alive ~pid
   and close () = Runtime_events.free_cursor cursor in
-  { alive; cursor; close; pid; exit_status }
+  { alive; cursor; close; origin = Attached; pid }
 
 let launch_process config (exec_args : exec_config) : subprocess =
   match exec_args with
@@ -340,7 +383,7 @@ let olly config exec_args =
           collect_events ~sample_rss:config.sample_rss
             config.process_poller_sleep config.poll_sleep child callbacks;
           config.on_success ());
-      child.exit_status ()
+      exit_status child
       |> Option.iter @@ function
          | Unix.WEXITED 0 -> ()
          | status ->

--- a/lib/olly_common/launch.mli
+++ b/lib/olly_common/launch.mli
@@ -1,0 +1,42 @@
+module Lost_events : sig
+  val were_events_lost : unit -> bool
+end
+
+type origin
+
+type subprocess = {
+  alive : unit -> bool;
+  cursor : Runtime_events.cursor;
+  close : unit -> unit;
+  origin : origin;
+  pid : int;
+}
+
+type runtime_events_config = { log_wsize : int option; dir : string option }
+type exec_config = Attach of string * int | Execute of string list
+
+exception Fail of string
+
+(* Exposed for [test_launch]: the tests exercise process launching directly,
+   without going through [olly]. *)
+val exec_process : runtime_events_config -> string list -> subprocess
+
+type 'r acceptor_fn = int -> Runtime_events.Timestamp.t -> 'r
+
+type consumer_config = {
+  runtime_begin : (Runtime_events.runtime_phase -> unit) acceptor_fn;
+  runtime_end : (Runtime_events.runtime_phase -> unit) acceptor_fn;
+  runtime_counter : (Runtime_events.runtime_counter -> int -> unit) acceptor_fn;
+  lifecycle : (Runtime_events.lifecycle -> int option -> unit) acceptor_fn;
+  extra : Runtime_events.Callbacks.t -> Runtime_events.Callbacks.t;
+  cleanup : unit -> unit;
+  on_success : unit -> unit;
+  process_poller_sleep : float;
+  sample_rss : bool;
+  poll_sleep : float;
+  runtime_events_dir : string option;
+  runtime_events_log_wsize : int option;
+}
+
+val empty_config : consumer_config
+val olly : consumer_config -> exec_config -> unit

--- a/lib/olly_common/platform.ml
+++ b/lib/olly_common/platform.ml
@@ -1,0 +1,44 @@
+type handle = int
+
+external olly_is_process_alive : int -> bool = "olly_is_process_alive"
+
+let is_process_alive ~pid = olly_is_process_alive pid
+
+external pid_of_handle : handle -> int = "olly_pid_of_handle"
+
+let create_process_env = Unix.create_process_env
+
+let waitpid flags handle =
+  match Unix.waitpid flags handle with 0, _ -> None | _, status -> Some status
+
+let terminate h = try Unix.kill h Sys.sigkill with Unix.Unix_error _ -> ()
+
+(* How long to wait for a child to die after we have terminated it. Bounded
+   because [waitpid []] on a process that refuses to die never returns, and
+   so that a caller can run as a [Fun.protect] finalizer, where hanging there
+   would strand olly at exit. *)
+let terminate_wait_timeout = 2.0
+let terminate_wait_interval = 0.005
+
+let terminate_and_reap handle =
+  terminate handle;
+  let deadline = Unix.gettimeofday () +. terminate_wait_timeout in
+  let rec wait () =
+    match waitpid [ Unix.WNOHANG ] handle with
+    | Some _ -> true
+    | None -> retry ()
+    (* Nothing left to reap: already gone, or never ours. *)
+    | exception Unix.Unix_error ((Unix.ECHILD | Unix.EBADF), _, _) -> true
+    | exception Unix.Unix_error (Unix.EINTR, _, _) -> retry ()
+  and retry () =
+    Unix.gettimeofday () < deadline
+    &&
+    ((try Unix.sleepf terminate_wait_interval
+      with Unix.Unix_error (Unix.EINTR, _, _) -> ());
+     wait ())
+  in
+  wait ()
+
+external olly_get_rss_kb : int -> int = "olly_get_rss_kb"
+
+let get_rss_kb ~pid = olly_get_rss_kb pid

--- a/lib/olly_common/platform.mli
+++ b/lib/olly_common/platform.mli
@@ -1,0 +1,31 @@
+type handle
+(** A process we spawned: a Win32 [HANDLE] on Windows, a pid elsewhere. Produced
+    by [create_process_env], consumed by [waitpid] and [terminate_and_reap]. *)
+
+val pid_of_handle : handle -> int
+(** The real OS pid, which is what the child names its ring file after. Raises
+    [Unix_error] if the handle is invalid or not queryable. *)
+
+val is_process_alive : pid:int -> bool
+(** For a process we did not spawn, and so have no handle for. *)
+
+val create_process_env :
+  string ->
+  string array ->
+  string array ->
+  Unix.file_descr ->
+  Unix.file_descr ->
+  Unix.file_descr ->
+  handle
+
+val waitpid : Unix.wait_flag list -> handle -> Unix.process_status option
+(** [None] means still running, and only arises under [WNOHANG]. On [Some] the
+    handle has been closed and must not be used again. *)
+
+val terminate_and_reap : handle -> bool
+(** Terminate [handle] and reap it. Returns whether it is actually gone within a
+    given time bound: on Windows [TerminateProcess] can fail, and until the
+    child dies it keeps the ring file mapped. *)
+
+val get_rss_kb : pid:int -> int
+(** Peak resident set size; 0 where unsupported, which includes Windows. *)

--- a/lib/olly_common/process_poller_5.0.ml
+++ b/lib/olly_common/process_poller_5.0.ml
@@ -1,5 +1,3 @@
-external get_rss_kb : int -> int = "olly_get_rss_kb"
-
 type t = {
   stop_flag : bool Atomic.t;
   domain : unit Domain.t;
@@ -31,7 +29,8 @@ let start ~alive_check ~pid ~interval ~sample_rss =
       Atomic.set alive still_alive;
       if still_alive then (
         if sample_rss then
-          Atomic.set peak_rss (max (get_rss_kb pid) (Atomic.get peak_rss));
+          Atomic.set peak_rss
+            (max (Platform.get_rss_kb ~pid) (Atomic.get peak_rss));
         sleep_at_least stop_flag interval;
         start_loop ()))
   in

--- a/lib/olly_common/process_poller_5.1.ml
+++ b/lib/olly_common/process_poller_5.1.ml
@@ -1,5 +1,3 @@
-external get_rss_kb : int -> int = "olly_get_rss_kb"
-
 (* [stop_rd]/[stop_wr] form a self-pipe, used for early termination of the 
    [select] in the polling domain. *)
 type t = {
@@ -41,7 +39,8 @@ let start ~alive_check ~pid ~interval ~sample_rss =
     Atomic.set alive still_alive;
     if still_alive then (
       if sample_rss then
-        Atomic.set peak_rss (max (get_rss_kb pid) (Atomic.get peak_rss));
+        Atomic.set peak_rss
+          (max (Platform.get_rss_kb ~pid) (Atomic.get peak_rss));
       (* wait for [interval], or until signalled to stop *)
       if sleep_until_write read_fds interval then start_loop read_fds)
   in

--- a/lib/olly_common/process_utils.c
+++ b/lib/olly_common/process_utils.c
@@ -1,6 +1,11 @@
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 
+/* [caml_win32_maperr] and [caml_uerror], for reporting a Win32 failure as the
+   [Unix.Unix_error] that the rest of the Unix bindings raise. This header
+   pulls in winsock2.h, which mingw wants to see before windows.h. */
+#include <caml/unixsupport.h>
+
 #ifdef _WIN32
 #include <windows.h>
 #else
@@ -34,5 +39,23 @@ CAMLprim value olly_is_process_alive(value v_pid) {
     CAMLreturn(Val_true);
   }
   CAMLreturn(Val_false);
+#endif
+}
+
+CAMLprim value olly_pid_of_handle(value v_handle) {
+  CAMLparam1(v_handle);
+#ifdef _WIN32
+  /* Unix.create_process stores the Win32 process HANDLE in the value, so go
+     through intnat rather than int: HANDLE is pointer-sized (64-bit on x64)
+     while int is 32-bit. This mirrors win32unix's own stubs. */
+  HANDLE handle = (HANDLE)Long_val(v_handle);
+  DWORD pid = GetProcessId(handle);
+  if (pid == 0) {
+    caml_win32_maperr(GetLastError());
+    caml_uerror("GetProcessId", Nothing);
+  }
+  CAMLreturn(Val_long(pid));
+#else
+  CAMLreturn(v_handle);
 #endif
 }

--- a/test/test_launch.ml
+++ b/test/test_launch.ml
@@ -23,12 +23,10 @@ let process_launch () =
   Alcotest.(check bool)
     "process should launch" true
     (try
-       let a = Launch.exec_process config [ "./run_endlessly.exe" ] in
-       try
-         (* Sending signal Zero to kill checks the process exists for Unix. *)
-         Unix.kill a.pid 0;
-         true
-       with Unix.Unix_error (Unix.ESRCH, _, _) -> false
+       let child = Launch.exec_process config [ "./run_endlessly.exe" ] in
+       (* [close] terminates it: left running, it would outlive the test and
+          hold the inherited stdout open, hanging whoever reads it (dune). *)
+       Fun.protect ~finally:child.close (fun () -> child.alive ())
      with
     (* Any exceptions indicate a failure to launch *)
     | Unix.Unix_error (Unix.ENOENT, _, _) -> false
@@ -49,11 +47,7 @@ let process_launch_slow_start () =
     Launch.exec_process config
       [ "/bin/sh"; "-c"; "sleep 0.5; exec ./run_endlessly.exe" ]
   in
-  Fun.protect
-    ~finally:(fun () ->
-      (try Unix.kill child.pid Sys.sigkill with Unix.Unix_error _ -> ());
-      child.close ())
-    (fun () ->
+  Fun.protect ~finally:child.close (fun () ->
       Alcotest.(check bool)
         "process with a slow start should be traced" true (child.alive ()))
 


### PR DESCRIPTION
On Windows, creating a process returns a handle, not a pid. Various process-manipulation functions require a handle on Windows, not a pid.

Changes include
- recording an `origin` instead of an `exit_status` closure, which carries information about whether we launched or attached the process (and so we no longer conflate "no exit status yet" and "we cannot know the status as we didn't launch the process")
- introduced a new stub on windows, which converts a handle to a pid.
- now the `close` closure will also kill a launched process on windows if still running, since not doing so means we cannot delete the ring file (if desired)
- Because of the semantics of handles and PIDs on Windows, introduce a
  Platform module meant to abstract all that detail away and allow type
  safe and portable interfaces for process handling.